### PR TITLE
feat(grid): implement grid trading strategy core with risk management

### DIFF
--- a/internal/strategy/grid/calculator.go
+++ b/internal/strategy/grid/calculator.go
@@ -1,0 +1,260 @@
+package grid
+
+import (
+	"github.com/shopspring/decimal"
+	"go.uber.org/zap"
+)
+
+// Calculator constants
+const (
+	// DefaultOrderPrecision is the decimal places for order size
+	DefaultOrderPrecision = 4
+	// DefaultRebuildMarginRatio is the multiplier for lower bound when rebuilding
+	// near zero prices (0.9 = 10% below current price)
+	DefaultRebuildMarginRatio = 0.9
+)
+
+// Calculator handles grid level calculations
+type Calculator struct {
+	logger         *zap.Logger
+	orderPrecision int32
+}
+
+// NewCalculator creates a new grid calculator with default precision
+func NewCalculator(logger *zap.Logger) *Calculator {
+	return NewCalculatorWithPrecision(logger, DefaultOrderPrecision)
+}
+
+// NewCalculatorWithPrecision creates a new grid calculator with custom precision
+func NewCalculatorWithPrecision(logger *zap.Logger, precision int32) *Calculator {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	if precision <= 0 {
+		precision = DefaultOrderPrecision
+	}
+	return &Calculator{
+		logger:         logger,
+		orderPrecision: precision,
+	}
+}
+
+// CalculateGridLevels calculates equal-width grid levels between upper and lower bounds
+// Returns gridCount+1 levels (inclusive of both bounds)
+func (c *Calculator) CalculateGridLevels(params GridParams) ([]*GridLevel, error) {
+	if err := c.validateParams(params); err != nil {
+		return nil, err
+	}
+
+	gridCount := params.GridCount
+	upper := params.UpperBound
+	lower := params.LowerBound
+
+	// Calculate grid spacing
+	// spacing = (upper - lower) / gridCount
+	spacing := upper.Sub(lower).Div(decimal.NewFromInt(int64(gridCount)))
+
+	levels := make([]*GridLevel, gridCount+1)
+	for i := 0; i <= gridCount; i++ {
+		// price = lower + (spacing * i)
+		price := lower.Add(spacing.Mul(decimal.NewFromInt(int64(i))))
+		levels[i] = &GridLevel{
+			Index:  i,
+			Price:  price,
+			Status: LevelEmpty,
+		}
+	}
+
+	c.logger.Info("Grid levels calculated",
+		zap.Int("count", len(levels)),
+		zap.String("lower", lower.String()),
+		zap.String("upper", upper.String()),
+		zap.String("spacing", spacing.String()))
+
+	return levels, nil
+}
+
+// CalculateOrderSize calculates the order size for each grid level
+// Formula: totalInvestment / gridCount / currentPrice / leverage
+func (c *Calculator) CalculateOrderSize(
+	params GridParams,
+	currentPrice decimal.Decimal,
+) decimal.Decimal {
+	if currentPrice.IsZero() || params.GridCount == 0 {
+		return decimal.Zero
+	}
+
+	// Investment per grid level
+	investmentPerGrid := params.TotalInvestment.Div(decimal.NewFromInt(int64(params.GridCount)))
+
+	// Size = investment / price * leverage
+	leverage := decimal.NewFromInt(int64(params.Leverage))
+	if leverage.IsZero() {
+		leverage = decimal.NewFromInt(1)
+	}
+
+	size := investmentPerGrid.Mul(leverage).Div(currentPrice)
+
+	// Round to configured decimal places (contract precision)
+	size = size.Round(c.orderPrecision)
+
+	c.logger.Debug("Order size calculated",
+		zap.String("investmentPerGrid", investmentPerGrid.String()),
+		zap.String("currentPrice", currentPrice.String()),
+		zap.String("size", size.String()))
+
+	return size
+}
+
+// FindGridIndex finds the grid index for a given price
+// Returns -1 if price is below lower bound, gridCount if above upper bound
+func (c *Calculator) FindGridIndex(levels []*GridLevel, price decimal.Decimal) int {
+	if len(levels) == 0 {
+		return -1
+	}
+
+	// Below lowest level
+	if price.LessThan(levels[0].Price) {
+		return -1
+	}
+
+	// Above highest level
+	if price.GreaterThanOrEqual(levels[len(levels)-1].Price) {
+		return len(levels) - 1
+	}
+
+	// Find the level just below or at the price
+	for i := len(levels) - 1; i >= 0; i-- {
+		if price.GreaterThanOrEqual(levels[i].Price) {
+			return i
+		}
+	}
+
+	return -1
+}
+
+// FindNearestLevelIndex finds the nearest grid level to a price
+func (c *Calculator) FindNearestLevelIndex(levels []*GridLevel, price decimal.Decimal) int {
+	if len(levels) == 0 {
+		return -1
+	}
+
+	nearestIndex := 0
+	minDiff := price.Sub(levels[0].Price).Abs()
+
+	for i := 1; i < len(levels); i++ {
+		diff := price.Sub(levels[i].Price).Abs()
+		if diff.LessThan(minDiff) {
+			minDiff = diff
+			nearestIndex = i
+		}
+	}
+
+	return nearestIndex
+}
+
+// NeedRebuild checks if the grid needs to be rebuilt
+// Returns true if current price is outside the grid bounds
+func (c *Calculator) NeedRebuild(levels []*GridLevel, currentPrice decimal.Decimal) bool {
+	if len(levels) < 2 {
+		return true
+	}
+
+	lowerBound := levels[0].Price
+	upperBound := levels[len(levels)-1].Price
+
+	return currentPrice.LessThan(lowerBound) || currentPrice.GreaterThan(upperBound)
+}
+
+// RebuildGrid creates a new grid centered around the current price
+// New bounds are calculated based on the original grid range ratio
+func (c *Calculator) RebuildGrid(
+	params GridParams,
+	currentPrice decimal.Decimal,
+) ([]*GridLevel, GridParams, error) {
+	if currentPrice.IsZero() {
+		return nil, params, NewStrategyError("RebuildGrid", ErrInvalidParams, map[string]interface{}{
+			"currentPrice": currentPrice.String(),
+		})
+	}
+
+	// Calculate original range
+	originalRange := params.UpperBound.Sub(params.LowerBound)
+	halfRange := originalRange.Div(decimal.NewFromInt(2))
+
+	// New bounds centered on current price
+	newParams := params
+	newParams.LowerBound = currentPrice.Sub(halfRange)
+	newParams.UpperBound = currentPrice.Add(halfRange)
+
+	// Ensure lower bound is positive
+	if newParams.LowerBound.LessThanOrEqual(decimal.Zero) {
+		newParams.LowerBound = currentPrice.Mul(decimal.NewFromFloat(DefaultRebuildMarginRatio))
+		newParams.UpperBound = newParams.LowerBound.Add(originalRange)
+	}
+
+	c.logger.Info("Rebuilding grid",
+		zap.String("currentPrice", currentPrice.String()),
+		zap.String("newLower", newParams.LowerBound.String()),
+		zap.String("newUpper", newParams.UpperBound.String()))
+
+	levels, err := c.CalculateGridLevels(newParams)
+	if err != nil {
+		return nil, params, err
+	}
+
+	return levels, newParams, nil
+}
+
+// GetGridSpacing returns the price spacing between grid levels
+func (c *Calculator) GetGridSpacing(levels []*GridLevel) decimal.Decimal {
+	if len(levels) < 2 {
+		return decimal.Zero
+	}
+	return levels[1].Price.Sub(levels[0].Price)
+}
+
+// GetOppositeLevel returns the level index for placing an opposite order
+// For a filled buy order at index i, the opposite sell should be at i+1
+// For a filled sell order at index i, the opposite buy should be at i-1
+func (c *Calculator) GetOppositeLevel(filledIndex int, side OrderSide, totalLevels int) int {
+	if side == OrderSideBuy {
+		// Buy filled -> sell at higher level
+		if filledIndex+1 < totalLevels {
+			return filledIndex + 1
+		}
+		return -1 // At upper bound, no opposite
+	}
+	// Sell filled -> buy at lower level
+	if filledIndex-1 >= 0 {
+		return filledIndex - 1
+	}
+	return -1 // At lower bound, no opposite
+}
+
+// validateParams validates grid parameters
+func (c *Calculator) validateParams(params GridParams) error {
+	if params.GridCount <= 0 {
+		return NewStrategyError("validateParams", ErrInvalidParams, map[string]interface{}{
+			"gridCount": params.GridCount,
+			"reason":    "grid count must be positive",
+		})
+	}
+
+	if params.UpperBound.LessThanOrEqual(params.LowerBound) {
+		return NewStrategyError("validateParams", ErrInvalidParams, map[string]interface{}{
+			"upperBound": params.UpperBound.String(),
+			"lowerBound": params.LowerBound.String(),
+			"reason":     "upper bound must be greater than lower bound",
+		})
+	}
+
+	if params.LowerBound.LessThanOrEqual(decimal.Zero) {
+		return NewStrategyError("validateParams", ErrInvalidParams, map[string]interface{}{
+			"lowerBound": params.LowerBound.String(),
+			"reason":     "lower bound must be positive",
+		})
+	}
+
+	return nil
+}

--- a/internal/strategy/grid/calculator_test.go
+++ b/internal/strategy/grid/calculator_test.go
@@ -1,0 +1,342 @@
+package grid
+
+import (
+	"testing"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func newTestCalculator() *Calculator {
+	return NewCalculator(zap.NewNop())
+}
+
+func TestCalculateGridLevels(t *testing.T) {
+	calc := newTestCalculator()
+
+	tests := []struct {
+		name            string
+		params          GridParams
+		expectedCount   int
+		expectedFirst   decimal.Decimal
+		expectedLast    decimal.Decimal
+		expectedSpacing decimal.Decimal
+		expectError     bool
+	}{
+		{
+			name: "10 grids from 40000 to 50000",
+			params: GridParams{
+				GridCount:  10,
+				LowerBound: decimal.NewFromInt(40000),
+				UpperBound: decimal.NewFromInt(50000),
+			},
+			expectedCount:   11, // 10 intervals = 11 levels
+			expectedFirst:   decimal.NewFromInt(40000),
+			expectedLast:    decimal.NewFromInt(50000),
+			expectedSpacing: decimal.NewFromInt(1000),
+			expectError:     false,
+		},
+		{
+			name: "5 grids from 100 to 200",
+			params: GridParams{
+				GridCount:  5,
+				LowerBound: decimal.NewFromInt(100),
+				UpperBound: decimal.NewFromInt(200),
+			},
+			expectedCount:   6,
+			expectedFirst:   decimal.NewFromInt(100),
+			expectedLast:    decimal.NewFromInt(200),
+			expectedSpacing: decimal.NewFromInt(20),
+			expectError:     false,
+		},
+		{
+			name: "invalid - zero grid count",
+			params: GridParams{
+				GridCount:  0,
+				LowerBound: decimal.NewFromInt(100),
+				UpperBound: decimal.NewFromInt(200),
+			},
+			expectError: true,
+		},
+		{
+			name: "invalid - upper less than lower",
+			params: GridParams{
+				GridCount:  10,
+				LowerBound: decimal.NewFromInt(200),
+				UpperBound: decimal.NewFromInt(100),
+			},
+			expectError: true,
+		},
+		{
+			name: "invalid - negative lower bound",
+			params: GridParams{
+				GridCount:  10,
+				LowerBound: decimal.NewFromInt(-100),
+				UpperBound: decimal.NewFromInt(100),
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			levels, err := calc.CalculateGridLevels(tt.params)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Len(t, levels, tt.expectedCount)
+			assert.True(t, levels[0].Price.Equal(tt.expectedFirst),
+				"first level: expected %s, got %s", tt.expectedFirst, levels[0].Price)
+			assert.True(t, levels[len(levels)-1].Price.Equal(tt.expectedLast),
+				"last level: expected %s, got %s", tt.expectedLast, levels[len(levels)-1].Price)
+
+			// Check spacing
+			if len(levels) > 1 {
+				spacing := levels[1].Price.Sub(levels[0].Price)
+				assert.True(t, spacing.Equal(tt.expectedSpacing),
+					"spacing: expected %s, got %s", tt.expectedSpacing, spacing)
+			}
+
+			// Check all levels have correct index
+			for i, level := range levels {
+				assert.Equal(t, i, level.Index)
+				assert.Equal(t, LevelEmpty, level.Status)
+			}
+		})
+	}
+}
+
+func TestCalculateOrderSize(t *testing.T) {
+	calc := newTestCalculator()
+
+	tests := []struct {
+		name         string
+		params       GridParams
+		currentPrice decimal.Decimal
+		expected     decimal.Decimal
+	}{
+		{
+			name: "basic calculation with leverage 10",
+			params: GridParams{
+				TotalInvestment: decimal.NewFromInt(10000),
+				GridCount:       10,
+				Leverage:        10,
+			},
+			currentPrice: decimal.NewFromInt(2000),
+			// 10000 / 10 = 1000 per grid
+			// 1000 * 10 / 2000 = 5
+			expected: decimal.NewFromInt(5),
+		},
+		{
+			name: "with leverage 1",
+			params: GridParams{
+				TotalInvestment: decimal.NewFromInt(10000),
+				GridCount:       10,
+				Leverage:        1,
+			},
+			currentPrice: decimal.NewFromInt(2000),
+			// 10000 / 10 = 1000 per grid
+			// 1000 * 1 / 2000 = 0.5
+			expected: decimal.NewFromFloat(0.5),
+		},
+		{
+			name: "zero price returns zero",
+			params: GridParams{
+				TotalInvestment: decimal.NewFromInt(10000),
+				GridCount:       10,
+				Leverage:        10,
+			},
+			currentPrice: decimal.Zero,
+			expected:     decimal.Zero,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := calc.CalculateOrderSize(tt.params, tt.currentPrice)
+			assert.True(t, result.Equal(tt.expected),
+				"expected %s, got %s", tt.expected, result)
+		})
+	}
+}
+
+func TestFindGridIndex(t *testing.T) {
+	calc := newTestCalculator()
+
+	// Create test levels: [100, 120, 140, 160, 180, 200]
+	levels := []*GridLevel{
+		{Index: 0, Price: decimal.NewFromInt(100)},
+		{Index: 1, Price: decimal.NewFromInt(120)},
+		{Index: 2, Price: decimal.NewFromInt(140)},
+		{Index: 3, Price: decimal.NewFromInt(160)},
+		{Index: 4, Price: decimal.NewFromInt(180)},
+		{Index: 5, Price: decimal.NewFromInt(200)},
+	}
+
+	tests := []struct {
+		name     string
+		price    decimal.Decimal
+		expected int
+	}{
+		{"at lowest level", decimal.NewFromInt(100), 0},
+		{"at highest level", decimal.NewFromInt(200), 5},
+		{"between levels", decimal.NewFromInt(130), 1},
+		{"exactly at level", decimal.NewFromInt(140), 2},
+		{"below lowest", decimal.NewFromInt(50), -1},
+		{"just above lowest", decimal.NewFromInt(101), 0},
+		{"just below highest", decimal.NewFromInt(199), 4},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := calc.FindGridIndex(levels, tt.price)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestFindNearestLevelIndex(t *testing.T) {
+	calc := newTestCalculator()
+
+	levels := []*GridLevel{
+		{Index: 0, Price: decimal.NewFromInt(100)},
+		{Index: 1, Price: decimal.NewFromInt(120)},
+		{Index: 2, Price: decimal.NewFromInt(140)},
+	}
+
+	tests := []struct {
+		name     string
+		price    decimal.Decimal
+		expected int
+	}{
+		{"exactly at level 0", decimal.NewFromInt(100), 0},
+		{"exactly at level 1", decimal.NewFromInt(120), 1},
+		{"closer to level 0", decimal.NewFromInt(105), 0},
+		{"closer to level 1", decimal.NewFromInt(115), 1},
+		{"midpoint - closer to lower", decimal.NewFromInt(110), 0}, // ties go to lower
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := calc.FindNearestLevelIndex(levels, tt.price)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestNeedRebuild(t *testing.T) {
+	calc := newTestCalculator()
+
+	levels := []*GridLevel{
+		{Index: 0, Price: decimal.NewFromInt(100)},
+		{Index: 1, Price: decimal.NewFromInt(150)},
+		{Index: 2, Price: decimal.NewFromInt(200)},
+	}
+
+	tests := []struct {
+		name     string
+		price    decimal.Decimal
+		expected bool
+	}{
+		{"within range", decimal.NewFromInt(150), false},
+		{"at lower bound", decimal.NewFromInt(100), false},
+		{"at upper bound", decimal.NewFromInt(200), false},
+		{"below lower bound", decimal.NewFromInt(99), true},
+		{"above upper bound", decimal.NewFromInt(201), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := calc.NeedRebuild(levels, tt.price)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestRebuildGrid(t *testing.T) {
+	calc := newTestCalculator()
+
+	params := GridParams{
+		InstID:     "ETH-USDT-SWAP",
+		GridCount:  10,
+		LowerBound: decimal.NewFromInt(40000),
+		UpperBound: decimal.NewFromInt(50000),
+	}
+
+	t.Run("rebuild centered on new price", func(t *testing.T) {
+		newPrice := decimal.NewFromInt(55000)
+		levels, newParams, err := calc.RebuildGrid(params, newPrice)
+
+		require.NoError(t, err)
+		assert.Len(t, levels, 11)
+
+		// New grid should be centered on 55000
+		// Original range = 10000, half = 5000
+		// New lower = 55000 - 5000 = 50000
+		// New upper = 55000 + 5000 = 60000
+		assert.True(t, newParams.LowerBound.Equal(decimal.NewFromInt(50000)))
+		assert.True(t, newParams.UpperBound.Equal(decimal.NewFromInt(60000)))
+	})
+
+	t.Run("error on zero price", func(t *testing.T) {
+		_, _, err := calc.RebuildGrid(params, decimal.Zero)
+		assert.Error(t, err)
+	})
+}
+
+func TestGetOppositeLevel(t *testing.T) {
+	calc := newTestCalculator()
+	totalLevels := 11 // 0-10
+
+	tests := []struct {
+		name        string
+		filledIndex int
+		side        OrderSide
+		expected    int
+	}{
+		{"buy at 0 -> sell at 1", 0, OrderSideBuy, 1},
+		{"buy at 5 -> sell at 6", 5, OrderSideBuy, 6},
+		{"buy at 10 (max) -> no opposite", 10, OrderSideBuy, -1},
+		{"sell at 10 -> buy at 9", 10, OrderSideSell, 9},
+		{"sell at 5 -> buy at 4", 5, OrderSideSell, 4},
+		{"sell at 0 (min) -> no opposite", 0, OrderSideSell, -1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := calc.GetOppositeLevel(tt.filledIndex, tt.side, totalLevels)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGetGridSpacing(t *testing.T) {
+	calc := newTestCalculator()
+
+	t.Run("normal spacing", func(t *testing.T) {
+		levels := []*GridLevel{
+			{Price: decimal.NewFromInt(100)},
+			{Price: decimal.NewFromInt(110)},
+			{Price: decimal.NewFromInt(120)},
+		}
+		spacing := calc.GetGridSpacing(levels)
+		assert.True(t, spacing.Equal(decimal.NewFromInt(10)))
+	})
+
+	t.Run("empty levels", func(t *testing.T) {
+		spacing := calc.GetGridSpacing([]*GridLevel{})
+		assert.True(t, spacing.IsZero())
+	})
+
+	t.Run("single level", func(t *testing.T) {
+		levels := []*GridLevel{{Price: decimal.NewFromInt(100)}}
+		spacing := calc.GetGridSpacing(levels)
+		assert.True(t, spacing.IsZero())
+	})
+}

--- a/internal/strategy/grid/errors.go
+++ b/internal/strategy/grid/errors.go
@@ -1,0 +1,83 @@
+package grid
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Sentinel errors for strategy operations
+var (
+	ErrStrategyNotRunning     = errors.New("strategy is not running")
+	ErrStrategyAlreadyRunning = errors.New("strategy is already running")
+	ErrStrategyStopping       = errors.New("strategy is stopping")
+	ErrInvalidParams          = errors.New("invalid strategy parameters")
+	ErrPriceOutOfRange        = errors.New("price is out of grid range")
+	ErrInsufficientBalance    = errors.New("insufficient balance")
+	ErrOrderFailed            = errors.New("order placement failed")
+	ErrOrderPartialFailure    = errors.New("some orders failed to place")
+	ErrOrderNotFound          = errors.New("order not found")
+	ErrRiskLimitExceeded      = errors.New("risk limit exceeded")
+	ErrStopLossTriggered      = errors.New("stop loss triggered")
+	ErrMaxDrawdownExceeded    = errors.New("maximum drawdown exceeded")
+	ErrExchangeError          = errors.New("exchange error")
+)
+
+// StrategyError wraps an error with operation context
+type StrategyError struct {
+	Op      string                 // Operation name
+	Err     error                  // Underlying error
+	Context map[string]interface{} // Additional context
+}
+
+// Error implements the error interface
+func (e *StrategyError) Error() string {
+	if len(e.Context) > 0 {
+		return fmt.Sprintf("%s: %v (context: %v)", e.Op, e.Err, e.Context)
+	}
+	return fmt.Sprintf("%s: %v", e.Op, e.Err)
+}
+
+// Unwrap returns the underlying error
+func (e *StrategyError) Unwrap() error {
+	return e.Err
+}
+
+// NewStrategyError creates a new strategy error
+func NewStrategyError(op string, err error, ctx map[string]interface{}) *StrategyError {
+	return &StrategyError{
+		Op:      op,
+		Err:     err,
+		Context: ctx,
+	}
+}
+
+// WrapError wraps an error with operation context
+func WrapError(op string, err error) *StrategyError {
+	return &StrategyError{
+		Op:  op,
+		Err: err,
+	}
+}
+
+// IsRetryable returns true if the error might succeed on retry
+func IsRetryable(err error) bool {
+	var stratErr *StrategyError
+	if errors.As(err, &stratErr) {
+		err = stratErr.Err
+	}
+
+	// Exchange errors might be temporary
+	if errors.Is(err, ErrExchangeError) {
+		return true
+	}
+
+	return false
+}
+
+// IsFatal returns true if the error requires strategy to stop
+func IsFatal(err error) bool {
+	return errors.Is(err, ErrStopLossTriggered) ||
+		errors.Is(err, ErrMaxDrawdownExceeded) ||
+		errors.Is(err, ErrRiskLimitExceeded) ||
+		errors.Is(err, ErrInsufficientBalance)
+}

--- a/internal/strategy/grid/order_manager.go
+++ b/internal/strategy/grid/order_manager.go
@@ -1,0 +1,422 @@
+package grid
+
+import (
+	"context"
+	"time"
+
+	"grid-trading-bot/internal/okx"
+
+	"github.com/shopspring/decimal"
+	"go.uber.org/zap"
+)
+
+// OrderManager handles all order operations for the grid strategy
+type OrderManager struct {
+	client     ExchangeClient
+	calculator *Calculator
+	logger     *zap.Logger
+}
+
+// NewOrderManager creates a new order manager
+func NewOrderManager(client ExchangeClient, calculator *Calculator, logger *zap.Logger) *OrderManager {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	return &OrderManager{
+		client:     client,
+		calculator: calculator,
+		logger:     logger,
+	}
+}
+
+// PlaceInitialOrders places initial grid orders based on current price
+// Orders below current price are buy orders, above are sell orders
+func (o *OrderManager) PlaceInitialOrders(
+	ctx context.Context,
+	strategy *Strategy,
+	currentPrice decimal.Decimal,
+) error {
+	if len(strategy.Levels) == 0 {
+		return NewStrategyError("PlaceInitialOrders", ErrInvalidParams, map[string]interface{}{
+			"reason": "no grid levels defined",
+		})
+	}
+
+	o.logger.Info("Placing initial grid orders",
+		zap.String("instId", strategy.Params.InstID),
+		zap.String("currentPrice", currentPrice.String()),
+		zap.Int("levelCount", len(strategy.Levels)))
+
+	successCount := 0
+	failCount := 0
+
+	for _, level := range strategy.Levels {
+		var orderID string
+		var side OrderSide
+		var err error
+
+		if level.Price.LessThan(currentPrice) {
+			// Below current price -> place buy order
+			orderID, err = o.placeBuyOrder(ctx, strategy, level)
+			side = OrderSideBuy
+			if err == nil {
+				level.SetBuyOrder(orderID)
+			}
+		} else if level.Price.GreaterThan(currentPrice) {
+			// Above current price -> place sell order
+			orderID, err = o.placeSellOrder(ctx, strategy, level)
+			side = OrderSideSell
+			if err == nil {
+				level.SetSellOrder(orderID)
+			}
+		}
+		// Skip level at current price
+
+		if err != nil {
+			o.logger.Error("Failed to place initial order",
+				zap.Int("gridIndex", level.Index),
+				zap.String("side", string(side)),
+				zap.String("price", level.Price.String()),
+				zap.Error(err))
+			failCount++
+			continue
+		}
+
+		if orderID != "" {
+			// Track order
+			strategy.AddOrder(&GridOrder{
+				OrderID:    orderID,
+				InstID:     strategy.Params.InstID,
+				Side:       side,
+				Price:      level.Price,
+				Size:       strategy.OrderSize,
+				GridIndex:  level.Index,
+				State:      OrderStateLive,
+				CreateTime: time.Now(),
+				UpdateTime: time.Now(),
+			})
+			successCount++
+		}
+	}
+
+	o.logger.Info("Initial orders placed",
+		zap.Int("success", successCount),
+		zap.Int("failed", failCount))
+
+	if successCount == 0 && failCount > 0 {
+		return NewStrategyError("PlaceInitialOrders", ErrOrderFailed, map[string]interface{}{
+			"failCount": failCount,
+		})
+	}
+
+	// Return partial failure warning if some orders failed
+	if failCount > 0 {
+		return NewStrategyError("PlaceInitialOrders", ErrOrderPartialFailure, map[string]interface{}{
+			"successCount": successCount,
+			"failCount":    failCount,
+		})
+	}
+
+	return nil
+}
+
+// PlaceOppositeOrder places an opposite order after one is filled
+// Buy filled at level i -> Sell at level i+1
+// Sell filled at level i -> Buy at level i-1
+func (o *OrderManager) PlaceOppositeOrder(
+	ctx context.Context,
+	strategy *Strategy,
+	filledOrder *GridOrder,
+) error {
+	oppositeIndex := o.calculator.GetOppositeLevel(
+		filledOrder.GridIndex,
+		filledOrder.Side,
+		len(strategy.Levels),
+	)
+
+	if oppositeIndex < 0 || oppositeIndex >= len(strategy.Levels) {
+		o.logger.Debug("No opposite level available",
+			zap.Int("filledIndex", filledOrder.GridIndex),
+			zap.String("side", string(filledOrder.Side)))
+		return nil
+	}
+
+	level := strategy.Levels[oppositeIndex]
+
+	var orderID string
+	var side OrderSide
+	var err error
+
+	if filledOrder.Side == OrderSideBuy {
+		// Buy filled -> place sell at higher level
+		orderID, err = o.placeSellOrder(ctx, strategy, level)
+		side = OrderSideSell
+		if err == nil {
+			level.SetSellOrder(orderID)
+		}
+	} else {
+		// Sell filled -> place buy at lower level
+		orderID, err = o.placeBuyOrder(ctx, strategy, level)
+		side = OrderSideBuy
+		if err == nil {
+			level.SetBuyOrder(orderID)
+		}
+	}
+
+	if err != nil {
+		return NewStrategyError("PlaceOppositeOrder", ErrOrderFailed, map[string]interface{}{
+			"side":       string(side),
+			"gridIndex":  oppositeIndex,
+			"price":      level.Price.String(),
+			"underlying": err.Error(),
+		})
+	}
+
+	// Track the new order
+	strategy.AddOrder(&GridOrder{
+		OrderID:    orderID,
+		InstID:     strategy.Params.InstID,
+		Side:       side,
+		Price:      level.Price,
+		Size:       strategy.OrderSize,
+		GridIndex:  oppositeIndex,
+		State:      OrderStateLive,
+		CreateTime: time.Now(),
+		UpdateTime: time.Now(),
+	})
+
+	o.logger.Info("Opposite order placed",
+		zap.String("orderId", orderID),
+		zap.String("side", string(side)),
+		zap.Int("gridIndex", oppositeIndex),
+		zap.String("price", level.Price.String()))
+
+	return nil
+}
+
+// CancelAllOrders cancels all pending orders for the strategy
+func (o *OrderManager) CancelAllOrders(ctx context.Context, strategy *Strategy) error {
+	instID := strategy.Params.InstID
+
+	// Get all pending orders from exchange
+	pending, err := o.client.GetPendingOrders(ctx, instID)
+	if err != nil {
+		return WrapError("GetPendingOrders", err)
+	}
+
+	if len(pending) == 0 {
+		o.logger.Info("No pending orders to cancel")
+		return nil
+	}
+
+	cancelReqs := make([]okx.CancelOrderRequest, 0, len(pending))
+	for _, order := range pending {
+		cancelReqs = append(cancelReqs, okx.CancelOrderRequest{
+			InstID:  instID,
+			OrderID: order.OrderID,
+		})
+	}
+
+	if err := o.client.CancelBatchOrders(ctx, cancelReqs); err != nil {
+		return WrapError("CancelBatchOrders", err)
+	}
+
+	// Clear local order tracking
+	strategy.mu.Lock()
+	strategy.Orders = make(map[string]*GridOrder)
+	strategy.mu.Unlock()
+
+	// Clear all levels using thread-safe method
+	for _, level := range strategy.Levels {
+		level.ClearAllOrders()
+	}
+
+	o.logger.Info("All orders cancelled",
+		zap.String("instId", instID),
+		zap.Int("count", len(pending)))
+
+	return nil
+}
+
+// CancelOrder cancels a specific order
+func (o *OrderManager) CancelOrder(ctx context.Context, strategy *Strategy, orderID string) error {
+	instID := strategy.Params.InstID
+
+	if err := o.client.CancelOrder(ctx, instID, orderID); err != nil {
+		return WrapError("CancelOrder", err)
+	}
+
+	// Update local state
+	gridOrder, ok := strategy.GetOrder(orderID)
+	if ok {
+		strategy.RemoveOrder(orderID)
+
+		// Update level status using thread-safe method
+		if gridOrder.GridIndex >= 0 && gridOrder.GridIndex < len(strategy.Levels) {
+			level := strategy.Levels[gridOrder.GridIndex]
+			if gridOrder.Side == OrderSideBuy {
+				level.ClearBuyOrder()
+			} else {
+				level.ClearSellOrder()
+			}
+		}
+	}
+
+	o.logger.Info("Order cancelled",
+		zap.String("orderId", orderID),
+		zap.String("instId", instID))
+
+	return nil
+}
+
+// SyncOrders synchronizes local order state with exchange
+func (o *OrderManager) SyncOrders(ctx context.Context, strategy *Strategy) error {
+	instID := strategy.Params.InstID
+
+	pending, err := o.client.GetPendingOrders(ctx, instID)
+	if err != nil {
+		return WrapError("GetPendingOrders", err)
+	}
+
+	// Build map of exchange orders
+	exchangeOrders := make(map[string]okx.Order)
+	for _, order := range pending {
+		exchangeOrders[order.OrderID] = order
+	}
+
+	// Update local state
+	strategy.mu.Lock()
+	defer strategy.mu.Unlock()
+
+	// Remove orders that no longer exist on exchange
+	for orderID := range strategy.Orders {
+		if _, exists := exchangeOrders[orderID]; !exists {
+			delete(strategy.Orders, orderID)
+		}
+	}
+
+	// Update existing orders
+	for orderID, gridOrder := range strategy.Orders {
+		if exchOrder, exists := exchangeOrders[orderID]; exists {
+			// Convert exchange state string to OrderState
+			state := OrderState(exchOrder.State)
+			if exchOrder.FilledSize != "" {
+				filledSize, _ := decimal.NewFromString(exchOrder.FilledSize)
+				gridOrder.UpdateFilled(filledSize, state)
+			} else {
+				gridOrder.UpdateState(state)
+			}
+		}
+	}
+
+	o.logger.Debug("Orders synchronized",
+		zap.String("instId", instID),
+		zap.Int("localOrders", len(strategy.Orders)),
+		zap.Int("exchangeOrders", len(pending)))
+
+	return nil
+}
+
+// placeOrder places a limit order at the specified grid level
+func (o *OrderManager) placeOrder(
+	ctx context.Context,
+	strategy *Strategy,
+	level *GridLevel,
+	side string,
+) (string, error) {
+	req := &okx.OrderRequest{
+		InstID:    strategy.Params.InstID,
+		TradeMode: strategy.Params.TradeMode.String(),
+		Side:      side,
+		OrderType: "limit",
+		Price:     level.Price.String(),
+		Size:      strategy.OrderSize.String(),
+	}
+
+	orderID, err := o.client.PlaceOrder(ctx, req)
+	if err != nil {
+		return "", err
+	}
+
+	o.logger.Debug("Order placed",
+		zap.String("orderId", orderID),
+		zap.String("side", side),
+		zap.Int("gridIndex", level.Index),
+		zap.String("price", level.Price.String()),
+		zap.String("size", strategy.OrderSize.String()))
+
+	return orderID, nil
+}
+
+// placeBuyOrder places a limit buy order at the specified grid level
+func (o *OrderManager) placeBuyOrder(
+	ctx context.Context,
+	strategy *Strategy,
+	level *GridLevel,
+) (string, error) {
+	return o.placeOrder(ctx, strategy, level, "buy")
+}
+
+// placeSellOrder places a limit sell order at the specified grid level
+func (o *OrderManager) placeSellOrder(
+	ctx context.Context,
+	strategy *Strategy,
+	level *GridLevel,
+) (string, error) {
+	return o.placeOrder(ctx, strategy, level, "sell")
+}
+
+// HandleOrderFilled processes a filled order and places the opposite order
+func (o *OrderManager) HandleOrderFilled(
+	ctx context.Context,
+	strategy *Strategy,
+	orderID string,
+	filledPrice decimal.Decimal,
+	filledSize decimal.Decimal,
+) error {
+	gridOrder, ok := strategy.GetOrder(orderID)
+	if !ok {
+		o.logger.Warn("Filled order not found in strategy",
+			zap.String("orderId", orderID))
+		return ErrOrderNotFound
+	}
+
+	// Update order state using thread-safe method
+	gridOrder.UpdateFilled(filledSize, OrderStateFilled)
+
+	// Update level status using thread-safe method
+	if gridOrder.GridIndex >= 0 && gridOrder.GridIndex < len(strategy.Levels) {
+		level := strategy.Levels[gridOrder.GridIndex]
+		if gridOrder.Side == OrderSideBuy {
+			level.ClearBuyOrder()
+		} else {
+			level.ClearSellOrder()
+		}
+	}
+
+	// Update metrics
+	strategy.UpdateMetrics(func(m *StrategyMetrics) {
+		m.TotalTrades++
+		m.UpdateTime = time.Now()
+	})
+
+	o.logger.Info("Order filled",
+		zap.String("orderId", orderID),
+		zap.String("side", string(gridOrder.Side)),
+		zap.Int("gridIndex", gridOrder.GridIndex),
+		zap.String("price", filledPrice.String()),
+		zap.String("size", filledSize.String()))
+
+	// Remove from active orders
+	strategy.RemoveOrder(orderID)
+
+	// Place opposite order
+	return o.PlaceOppositeOrder(ctx, strategy, gridOrder)
+}
+
+// GetActiveOrderCount returns the number of active orders
+func (o *OrderManager) GetActiveOrderCount(strategy *Strategy) int {
+	strategy.mu.RLock()
+	defer strategy.mu.RUnlock()
+	return len(strategy.Orders)
+}

--- a/internal/strategy/grid/order_manager_test.go
+++ b/internal/strategy/grid/order_manager_test.go
@@ -1,0 +1,397 @@
+package grid
+
+import (
+	"context"
+	"testing"
+
+	"grid-trading-bot/internal/okx"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func newTestStrategy() *Strategy {
+	params := GridParams{
+		InstID:          "ETH-USDT-SWAP",
+		LowerBound:      decimal.NewFromInt(2000),
+		UpperBound:      decimal.NewFromInt(2500),
+		GridCount:       5,
+		TotalInvestment: decimal.NewFromInt(10000),
+		Leverage:        10,
+		TradeMode:       "cross",
+	}
+
+	strategy := NewStrategy("test-strategy", params, RiskParams{})
+
+	// Create grid levels: 2000, 2100, 2200, 2300, 2400, 2500
+	strategy.Levels = []*GridLevel{
+		{Index: 0, Price: decimal.NewFromInt(2000), Status: LevelEmpty},
+		{Index: 1, Price: decimal.NewFromInt(2100), Status: LevelEmpty},
+		{Index: 2, Price: decimal.NewFromInt(2200), Status: LevelEmpty},
+		{Index: 3, Price: decimal.NewFromInt(2300), Status: LevelEmpty},
+		{Index: 4, Price: decimal.NewFromInt(2400), Status: LevelEmpty},
+		{Index: 5, Price: decimal.NewFromInt(2500), Status: LevelEmpty},
+	}
+
+	strategy.OrderSize = decimal.NewFromFloat(0.5)
+
+	return strategy
+}
+
+func newTestOrderManager(client ExchangeClient) *OrderManager {
+	calc := NewCalculator(zap.NewNop())
+	return NewOrderManager(client, calc, zap.NewNop())
+}
+
+func TestPlaceInitialOrders(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("place orders above and below current price", func(t *testing.T) {
+		buyOrders := 0
+		sellOrders := 0
+
+		mockClient := &MockExchangeClient{
+			PlaceOrderFunc: func(ctx context.Context, req *okx.OrderRequest) (string, error) {
+				if req.Side == "buy" {
+					buyOrders++
+					return "buy-order-" + req.Price, nil
+				}
+				sellOrders++
+				return "sell-order-" + req.Price, nil
+			},
+		}
+
+		orderMgr := newTestOrderManager(mockClient)
+		strategy := newTestStrategy()
+
+		// Current price at 2250 (between level 2 and 3)
+		currentPrice := decimal.NewFromInt(2250)
+
+		err := orderMgr.PlaceInitialOrders(ctx, strategy, currentPrice)
+		require.NoError(t, err)
+
+		// Levels 0,1,2 (2000, 2100, 2200) are below -> buy orders
+		// Levels 3,4,5 (2300, 2400, 2500) are above -> sell orders
+		assert.Equal(t, 3, buyOrders)
+		assert.Equal(t, 3, sellOrders)
+
+		// Check order tracking
+		assert.Equal(t, 6, len(strategy.Orders))
+	})
+
+	t.Run("place only buy orders when price at upper bound", func(t *testing.T) {
+		buyOrders := 0
+		sellOrders := 0
+
+		mockClient := &MockExchangeClient{
+			PlaceOrderFunc: func(ctx context.Context, req *okx.OrderRequest) (string, error) {
+				if req.Side == "buy" {
+					buyOrders++
+				} else {
+					sellOrders++
+				}
+				return "order-id", nil
+			},
+		}
+
+		orderMgr := newTestOrderManager(mockClient)
+		strategy := newTestStrategy()
+
+		// Current price at 2600 (above all levels)
+		currentPrice := decimal.NewFromInt(2600)
+
+		err := orderMgr.PlaceInitialOrders(ctx, strategy, currentPrice)
+		require.NoError(t, err)
+
+		assert.Equal(t, 6, buyOrders) // All levels below current price
+		assert.Equal(t, 0, sellOrders)
+	})
+
+	t.Run("empty levels returns error", func(t *testing.T) {
+		mockClient := &MockExchangeClient{}
+		orderMgr := newTestOrderManager(mockClient)
+
+		strategy := NewStrategy("test", GridParams{}, RiskParams{})
+		strategy.Levels = []*GridLevel{} // Empty
+
+		err := orderMgr.PlaceInitialOrders(ctx, strategy, decimal.NewFromInt(100))
+		assert.Error(t, err)
+	})
+}
+
+func TestPlaceOppositeOrder(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("buy filled -> sell at higher level", func(t *testing.T) {
+		var placedOrder *okx.OrderRequest
+
+		mockClient := &MockExchangeClient{
+			PlaceOrderFunc: func(ctx context.Context, req *okx.OrderRequest) (string, error) {
+				placedOrder = req
+				return "opposite-order-id", nil
+			},
+		}
+
+		orderMgr := newTestOrderManager(mockClient)
+		strategy := newTestStrategy()
+
+		// Simulate filled buy order at level 2
+		filledOrder := &GridOrder{
+			OrderID:   "filled-buy",
+			Side:      "buy",
+			GridIndex: 2,
+			Price:     decimal.NewFromInt(2200),
+		}
+
+		err := orderMgr.PlaceOppositeOrder(ctx, strategy, filledOrder)
+		require.NoError(t, err)
+
+		// Should place sell at level 3
+		assert.NotNil(t, placedOrder)
+		assert.Equal(t, "sell", placedOrder.Side)
+		assert.Equal(t, "2300", placedOrder.Price) // Level 3 price
+	})
+
+	t.Run("sell filled -> buy at lower level", func(t *testing.T) {
+		var placedOrder *okx.OrderRequest
+
+		mockClient := &MockExchangeClient{
+			PlaceOrderFunc: func(ctx context.Context, req *okx.OrderRequest) (string, error) {
+				placedOrder = req
+				return "opposite-order-id", nil
+			},
+		}
+
+		orderMgr := newTestOrderManager(mockClient)
+		strategy := newTestStrategy()
+
+		// Simulate filled sell order at level 3
+		filledOrder := &GridOrder{
+			OrderID:   "filled-sell",
+			Side:      "sell",
+			GridIndex: 3,
+			Price:     decimal.NewFromInt(2300),
+		}
+
+		err := orderMgr.PlaceOppositeOrder(ctx, strategy, filledOrder)
+		require.NoError(t, err)
+
+		// Should place buy at level 2
+		assert.NotNil(t, placedOrder)
+		assert.Equal(t, "buy", placedOrder.Side)
+		assert.Equal(t, "2200", placedOrder.Price) // Level 2 price
+	})
+
+	t.Run("buy at top level - no opposite", func(t *testing.T) {
+		orderPlaced := false
+
+		mockClient := &MockExchangeClient{
+			PlaceOrderFunc: func(ctx context.Context, req *okx.OrderRequest) (string, error) {
+				orderPlaced = true
+				return "order-id", nil
+			},
+		}
+
+		orderMgr := newTestOrderManager(mockClient)
+		strategy := newTestStrategy()
+
+		// Buy filled at top level
+		filledOrder := &GridOrder{
+			OrderID:   "filled-buy",
+			Side:      "buy",
+			GridIndex: 5, // Top level
+		}
+
+		err := orderMgr.PlaceOppositeOrder(ctx, strategy, filledOrder)
+		require.NoError(t, err)
+
+		// No order should be placed (no level above)
+		assert.False(t, orderPlaced)
+	})
+
+	t.Run("sell at bottom level - no opposite", func(t *testing.T) {
+		orderPlaced := false
+
+		mockClient := &MockExchangeClient{
+			PlaceOrderFunc: func(ctx context.Context, req *okx.OrderRequest) (string, error) {
+				orderPlaced = true
+				return "order-id", nil
+			},
+		}
+
+		orderMgr := newTestOrderManager(mockClient)
+		strategy := newTestStrategy()
+
+		// Sell filled at bottom level
+		filledOrder := &GridOrder{
+			OrderID:   "filled-sell",
+			Side:      "sell",
+			GridIndex: 0, // Bottom level
+		}
+
+		err := orderMgr.PlaceOppositeOrder(ctx, strategy, filledOrder)
+		require.NoError(t, err)
+
+		// No order should be placed (no level below)
+		assert.False(t, orderPlaced)
+	})
+}
+
+func TestCancelAllOrders(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("cancel multiple orders", func(t *testing.T) {
+		cancelCalled := false
+		cancelledOrders := 0
+
+		mockClient := &MockExchangeClient{
+			GetPendingOrdersFunc: func(ctx context.Context, instID string) ([]okx.Order, error) {
+				return []okx.Order{
+					{OrderID: "order1"},
+					{OrderID: "order2"},
+					{OrderID: "order3"},
+				}, nil
+			},
+			CancelBatchOrdersFunc: func(ctx context.Context, orders []okx.CancelOrderRequest) error {
+				cancelCalled = true
+				cancelledOrders = len(orders)
+				return nil
+			},
+		}
+
+		orderMgr := newTestOrderManager(mockClient)
+		strategy := newTestStrategy()
+
+		// Add some tracked orders
+		strategy.AddOrder(&GridOrder{OrderID: "order1", GridIndex: 0, Side: "buy"})
+		strategy.AddOrder(&GridOrder{OrderID: "order2", GridIndex: 1, Side: "buy"})
+
+		err := orderMgr.CancelAllOrders(ctx, strategy)
+		require.NoError(t, err)
+
+		assert.True(t, cancelCalled)
+		assert.Equal(t, 3, cancelledOrders)
+		assert.Empty(t, strategy.Orders)
+	})
+
+	t.Run("no orders to cancel", func(t *testing.T) {
+		cancelCalled := false
+
+		mockClient := &MockExchangeClient{
+			GetPendingOrdersFunc: func(ctx context.Context, instID string) ([]okx.Order, error) {
+				return []okx.Order{}, nil
+			},
+			CancelBatchOrdersFunc: func(ctx context.Context, orders []okx.CancelOrderRequest) error {
+				cancelCalled = true
+				return nil
+			},
+		}
+
+		orderMgr := newTestOrderManager(mockClient)
+		strategy := newTestStrategy()
+
+		err := orderMgr.CancelAllOrders(ctx, strategy)
+		require.NoError(t, err)
+
+		assert.False(t, cancelCalled)
+	})
+}
+
+func TestHandleOrderFilled(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("handle buy order filled", func(t *testing.T) {
+		oppositeOrderPlaced := false
+
+		mockClient := &MockExchangeClient{
+			PlaceOrderFunc: func(ctx context.Context, req *okx.OrderRequest) (string, error) {
+				oppositeOrderPlaced = true
+				assert.Equal(t, "sell", req.Side) // Opposite of buy
+				return "opposite-order", nil
+			},
+		}
+
+		orderMgr := newTestOrderManager(mockClient)
+		strategy := newTestStrategy()
+
+		// Add a buy order
+		strategy.AddOrder(&GridOrder{
+			OrderID:   "buy-order-1",
+			Side:      "buy",
+			GridIndex: 2,
+			Price:     decimal.NewFromInt(2200),
+		})
+
+		err := orderMgr.HandleOrderFilled(ctx, strategy, "buy-order-1",
+			decimal.NewFromInt(2200), decimal.NewFromFloat(0.5))
+
+		require.NoError(t, err)
+		assert.True(t, oppositeOrderPlaced)
+
+		// Original order should be removed
+		_, exists := strategy.GetOrder("buy-order-1")
+		assert.False(t, exists)
+
+		// Metrics should be updated
+		metrics := strategy.GetMetrics()
+		assert.Equal(t, 1, metrics.TotalTrades)
+	})
+
+	t.Run("handle unknown order", func(t *testing.T) {
+		mockClient := &MockExchangeClient{}
+		orderMgr := newTestOrderManager(mockClient)
+		strategy := newTestStrategy()
+
+		err := orderMgr.HandleOrderFilled(ctx, strategy, "unknown-order",
+			decimal.NewFromInt(2200), decimal.NewFromFloat(0.5))
+
+		assert.ErrorIs(t, err, ErrOrderNotFound)
+	})
+}
+
+func TestSyncOrders(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("sync removes stale orders", func(t *testing.T) {
+		mockClient := &MockExchangeClient{
+			GetPendingOrdersFunc: func(ctx context.Context, instID string) ([]okx.Order, error) {
+				// Only order1 exists on exchange
+				return []okx.Order{
+					{OrderID: "order1", State: "live"},
+				}, nil
+			},
+		}
+
+		orderMgr := newTestOrderManager(mockClient)
+		strategy := newTestStrategy()
+
+		// Add two orders locally
+		strategy.AddOrder(&GridOrder{OrderID: "order1", GridIndex: 0})
+		strategy.AddOrder(&GridOrder{OrderID: "order2", GridIndex: 1}) // This one is stale
+
+		err := orderMgr.SyncOrders(ctx, strategy)
+		require.NoError(t, err)
+
+		// Only order1 should remain
+		assert.Equal(t, 1, len(strategy.Orders))
+		_, exists := strategy.GetOrder("order1")
+		assert.True(t, exists)
+		_, exists = strategy.GetOrder("order2")
+		assert.False(t, exists)
+	})
+}
+
+func TestGetActiveOrderCount(t *testing.T) {
+	mockClient := &MockExchangeClient{}
+	orderMgr := newTestOrderManager(mockClient)
+	strategy := newTestStrategy()
+
+	assert.Equal(t, 0, orderMgr.GetActiveOrderCount(strategy))
+
+	strategy.AddOrder(&GridOrder{OrderID: "order1"})
+	strategy.AddOrder(&GridOrder{OrderID: "order2"})
+
+	assert.Equal(t, 2, orderMgr.GetActiveOrderCount(strategy))
+}

--- a/internal/strategy/grid/risk_controller.go
+++ b/internal/strategy/grid/risk_controller.go
@@ -1,0 +1,368 @@
+package grid
+
+import (
+	"context"
+	"time"
+
+	"grid-trading-bot/internal/okx"
+
+	"github.com/shopspring/decimal"
+	"go.uber.org/zap"
+)
+
+// Default constants for risk management
+const (
+	DefaultQuoteCurrency = "USDT" // Default quote currency for balance queries
+)
+
+// ExchangeClient defines the interface for exchange operations
+// This allows easy mocking for tests
+type ExchangeClient interface {
+	GetBalance(ctx context.Context, currency string) (*okx.Balance, error)
+	GetPositions(ctx context.Context, instID string) ([]okx.Position, error)
+	PlaceOrder(ctx context.Context, req *okx.OrderRequest) (string, error)
+	CancelOrder(ctx context.Context, instID, orderID string) error
+	CancelBatchOrders(ctx context.Context, orders []okx.CancelOrderRequest) error
+	GetPendingOrders(ctx context.Context, instID string) ([]okx.Order, error)
+	GetTicker(ctx context.Context, instID string) (*okx.Ticker, error)
+}
+
+// RiskController handles all risk management operations
+type RiskController struct {
+	params        RiskParams
+	client        ExchangeClient
+	logger        *zap.Logger
+	quoteCurrency string
+}
+
+// NewRiskController creates a new risk controller with default quote currency
+func NewRiskController(params RiskParams, client ExchangeClient, logger *zap.Logger) *RiskController {
+	return NewRiskControllerWithCurrency(params, client, logger, DefaultQuoteCurrency)
+}
+
+// NewRiskControllerWithCurrency creates a new risk controller with custom quote currency
+func NewRiskControllerWithCurrency(params RiskParams, client ExchangeClient, logger *zap.Logger, quoteCurrency string) *RiskController {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	if quoteCurrency == "" {
+		quoteCurrency = DefaultQuoteCurrency
+	}
+	return &RiskController{
+		params:        params,
+		client:        client,
+		logger:        logger,
+		quoteCurrency: quoteCurrency,
+	}
+}
+
+// ShouldStopLoss checks if stop loss should be triggered
+// Returns true if currentEquity / initialEquity < (1 - stopLossRatio)
+// Example: if stopLossRatio = 0.2, stop when equity drops below 80%
+// Safety: Returns false if initialEquity is zero to prevent divide-by-zero
+func (r *RiskController) ShouldStopLoss(metrics StrategyMetrics) bool {
+	// Safety: Prevent divide-by-zero when initialEquity hasn't been set
+	if metrics.InitialEquity.IsZero() {
+		return false
+	}
+
+	ratio := metrics.CurrentEquity.Div(metrics.InitialEquity)
+	threshold := decimal.NewFromInt(1).Sub(r.params.StopLossRatio)
+
+	shouldStop := ratio.LessThan(threshold)
+
+	if shouldStop {
+		r.logger.Warn("Stop loss condition detected",
+			zap.String("currentEquity", metrics.CurrentEquity.String()),
+			zap.String("initialEquity", metrics.InitialEquity.String()),
+			zap.String("ratio", ratio.String()),
+			zap.String("threshold", threshold.String()))
+	}
+
+	return shouldStop
+}
+
+// CheckMaxDrawdown checks if maximum drawdown has been exceeded
+func (r *RiskController) CheckMaxDrawdown(metrics StrategyMetrics) bool {
+	if r.params.MaxDrawdown.IsZero() {
+		return false
+	}
+
+	exceeded := metrics.MaxDrawdown.GreaterThan(r.params.MaxDrawdown)
+
+	if exceeded {
+		r.logger.Warn("Max drawdown exceeded",
+			zap.String("currentDrawdown", metrics.MaxDrawdown.String()),
+			zap.String("maxAllowed", r.params.MaxDrawdown.String()))
+	}
+
+	return exceeded
+}
+
+// CheckRisk performs all risk checks and returns an error if any risk limit is exceeded
+func (r *RiskController) CheckRisk(metrics StrategyMetrics) error {
+	if r.ShouldStopLoss(metrics) {
+		return ErrStopLossTriggered
+	}
+
+	if r.CheckMaxDrawdown(metrics) {
+		return ErrMaxDrawdownExceeded
+	}
+
+	return nil
+}
+
+// EquityUpdate holds the result of an equity calculation
+type EquityUpdate struct {
+	CurrentEquity decimal.Decimal
+	UnrealizedPnL decimal.Decimal
+	PeakEquity    decimal.Decimal
+	MaxDrawdown   decimal.Decimal
+}
+
+// CalculateEquity calculates the current equity without modifying any state
+// Returns an EquityUpdate that can be applied to metrics via Strategy.UpdateMetrics
+func (r *RiskController) CalculateEquity(ctx context.Context, instID string, currentPeak, currentMaxDrawdown decimal.Decimal) (*EquityUpdate, error) {
+	// Get current balance
+	balance, err := r.client.GetBalance(ctx, r.quoteCurrency)
+	if err != nil {
+		return nil, WrapError("GetBalance", err)
+	}
+
+	availableBalance, err := decimal.NewFromString(balance.Available)
+	if err != nil {
+		return nil, WrapError("ParseBalance", err)
+	}
+
+	// Get current positions and unrealized P&L
+	positions, err := r.client.GetPositions(ctx, instID)
+	if err != nil {
+		return nil, WrapError("GetPositions", err)
+	}
+
+	unrealizedPnL := decimal.Zero
+	for _, pos := range positions {
+		pnl, err := decimal.NewFromString(pos.UnrealizedPnL)
+		if err != nil {
+			continue
+		}
+		unrealizedPnL = unrealizedPnL.Add(pnl)
+	}
+
+	// Current equity = available balance + unrealized P&L
+	currentEquity := availableBalance.Add(unrealizedPnL)
+
+	// Calculate peak equity
+	peakEquity := currentPeak
+	if currentEquity.GreaterThan(peakEquity) {
+		peakEquity = currentEquity
+	}
+
+	// Calculate drawdown
+	// Safety: Only calculate drawdown when peakEquity > 0 to prevent divide-by-zero.
+	// This check is necessary because peakEquity could be zero if no trades have occurred yet.
+	maxDrawdown := currentMaxDrawdown
+	if peakEquity.GreaterThan(decimal.Zero) {
+		drawdown := peakEquity.Sub(currentEquity).Div(peakEquity)
+		if drawdown.GreaterThan(maxDrawdown) {
+			maxDrawdown = drawdown
+		}
+	}
+
+	r.logger.Debug("Equity calculated",
+		zap.String("currentEquity", currentEquity.String()),
+		zap.String("unrealizedPnL", unrealizedPnL.String()),
+		zap.String("maxDrawdown", maxDrawdown.String()))
+
+	return &EquityUpdate{
+		CurrentEquity: currentEquity,
+		UnrealizedPnL: unrealizedPnL,
+		PeakEquity:    peakEquity,
+		MaxDrawdown:   maxDrawdown,
+	}, nil
+}
+
+// InitializeEquity sets the initial equity for the strategy
+// It considers both available balance and unrealized P&L from existing positions
+func (r *RiskController) InitializeEquity(ctx context.Context, metrics *StrategyMetrics, instID string) error {
+	balance, err := r.client.GetBalance(ctx, r.quoteCurrency)
+	if err != nil {
+		return WrapError("GetBalance", err)
+	}
+
+	availableBalance, err := decimal.NewFromString(balance.Available)
+	if err != nil {
+		return WrapError("ParseBalance", err)
+	}
+
+	// Also consider unrealized P&L from existing positions
+	unrealizedPnL := decimal.Zero
+	if instID != "" {
+		positions, err := r.client.GetPositions(ctx, instID)
+		if err != nil {
+			r.logger.Warn("Failed to get positions during equity init, using balance only",
+				zap.Error(err))
+		} else {
+			for _, pos := range positions {
+				pnl, err := decimal.NewFromString(pos.UnrealizedPnL)
+				if err != nil {
+					continue
+				}
+				unrealizedPnL = unrealizedPnL.Add(pnl)
+			}
+		}
+	}
+
+	initialEquity := availableBalance.Add(unrealizedPnL)
+
+	metrics.InitialEquity = initialEquity
+	metrics.CurrentEquity = initialEquity
+	metrics.PeakEquity = initialEquity
+	metrics.UnrealizedPnL = unrealizedPnL
+	metrics.UpdateTime = time.Now()
+
+	r.logger.Info("Initial equity set",
+		zap.String("availableBalance", availableBalance.String()),
+		zap.String("unrealizedPnL", unrealizedPnL.String()),
+		zap.String("initialEquity", initialEquity.String()))
+
+	return nil
+}
+
+// EmergencyClose cancels all orders and closes all positions
+func (r *RiskController) EmergencyClose(ctx context.Context, instID string, tradeMode TradeMode) error {
+	r.logger.Warn("Executing emergency close", zap.String("instId", instID))
+
+	// Step 1: Cancel all pending orders
+	if err := r.cancelAllOrders(ctx, instID); err != nil {
+		r.logger.Error("Failed to cancel orders during emergency close", zap.Error(err))
+		// Continue with position closure even if order cancellation fails
+	}
+
+	// Step 2: Close all positions
+	if err := r.closeAllPositions(ctx, instID, tradeMode); err != nil {
+		return WrapError("EmergencyClose", err)
+	}
+
+	r.logger.Info("Emergency close completed", zap.String("instId", instID))
+	return nil
+}
+
+// cancelAllOrders cancels all pending orders for the instrument
+func (r *RiskController) cancelAllOrders(ctx context.Context, instID string) error {
+	pending, err := r.client.GetPendingOrders(ctx, instID)
+	if err != nil {
+		return err
+	}
+
+	if len(pending) == 0 {
+		return nil
+	}
+
+	cancelReqs := make([]okx.CancelOrderRequest, len(pending))
+	for i, order := range pending {
+		cancelReqs[i] = okx.CancelOrderRequest{
+			InstID:  instID,
+			OrderID: order.OrderID,
+		}
+	}
+
+	if err := r.client.CancelBatchOrders(ctx, cancelReqs); err != nil {
+		return err
+	}
+
+	r.logger.Info("Cancelled all pending orders",
+		zap.String("instId", instID),
+		zap.Int("count", len(pending)))
+
+	return nil
+}
+
+// closeAllPositions closes all open positions with market orders
+func (r *RiskController) closeAllPositions(ctx context.Context, instID string, tradeMode TradeMode) error {
+	positions, err := r.client.GetPositions(ctx, instID)
+	if err != nil {
+		return err
+	}
+
+	// Use provided tradeMode or default to cross
+	effectiveTradeMode := tradeMode
+	if effectiveTradeMode == "" {
+		effectiveTradeMode = TradeModeCross
+	}
+
+	for _, pos := range positions {
+		posSize, err := decimal.NewFromString(pos.Position)
+		if err != nil {
+			continue
+		}
+
+		if posSize.IsZero() {
+			continue
+		}
+
+		// Determine side for closing
+		side := "sell"
+		if posSize.IsNegative() {
+			side = "buy"
+			posSize = posSize.Abs()
+		}
+
+		orderReq := &okx.OrderRequest{
+			InstID:     instID,
+			TradeMode:  effectiveTradeMode.String(),
+			Side:       side,
+			OrderType:  "market",
+			Size:       posSize.String(),
+			ReduceOnly: true,
+		}
+
+		orderID, err := r.client.PlaceOrder(ctx, orderReq)
+		if err != nil {
+			r.logger.Error("Failed to close position",
+				zap.String("instId", instID),
+				zap.String("side", side),
+				zap.String("size", posSize.String()),
+				zap.Error(err))
+			return err
+		}
+
+		r.logger.Info("Position close order placed",
+			zap.String("orderId", orderID),
+			zap.String("instId", instID),
+			zap.String("side", side),
+			zap.String("size", posSize.String()))
+	}
+
+	return nil
+}
+
+// HasOpenPosition checks if there are any open positions
+func (r *RiskController) HasOpenPosition(ctx context.Context, instID string) (bool, decimal.Decimal, error) {
+	positions, err := r.client.GetPositions(ctx, instID)
+	if err != nil {
+		return false, decimal.Zero, err
+	}
+
+	totalPosition := decimal.Zero
+	for _, pos := range positions {
+		posSize, err := decimal.NewFromString(pos.Position)
+		if err != nil {
+			continue
+		}
+		totalPosition = totalPosition.Add(posSize)
+	}
+
+	hasPosition := !totalPosition.IsZero()
+	return hasPosition, totalPosition, nil
+}
+
+// GetParams returns the risk parameters
+func (r *RiskController) GetParams() RiskParams {
+	return r.params
+}
+
+// UpdateParams updates the risk parameters
+func (r *RiskController) UpdateParams(params RiskParams) {
+	r.params = params
+}

--- a/internal/strategy/grid/risk_controller_test.go
+++ b/internal/strategy/grid/risk_controller_test.go
@@ -1,0 +1,475 @@
+package grid
+
+import (
+	"context"
+	"testing"
+
+	"grid-trading-bot/internal/okx"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// MockExchangeClient implements ExchangeClient for testing
+type MockExchangeClient struct {
+	GetBalanceFunc        func(ctx context.Context, currency string) (*okx.Balance, error)
+	GetPositionsFunc      func(ctx context.Context, instID string) ([]okx.Position, error)
+	PlaceOrderFunc        func(ctx context.Context, req *okx.OrderRequest) (string, error)
+	CancelOrderFunc       func(ctx context.Context, instID, orderID string) error
+	CancelBatchOrdersFunc func(ctx context.Context, orders []okx.CancelOrderRequest) error
+	GetPendingOrdersFunc  func(ctx context.Context, instID string) ([]okx.Order, error)
+	GetTickerFunc         func(ctx context.Context, instID string) (*okx.Ticker, error)
+}
+
+func (m *MockExchangeClient) GetBalance(ctx context.Context, currency string) (*okx.Balance, error) {
+	if m.GetBalanceFunc != nil {
+		return m.GetBalanceFunc(ctx, currency)
+	}
+	return &okx.Balance{Available: "10000"}, nil
+}
+
+func (m *MockExchangeClient) GetPositions(ctx context.Context, instID string) ([]okx.Position, error) {
+	if m.GetPositionsFunc != nil {
+		return m.GetPositionsFunc(ctx, instID)
+	}
+	return []okx.Position{}, nil
+}
+
+func (m *MockExchangeClient) PlaceOrder(ctx context.Context, req *okx.OrderRequest) (string, error) {
+	if m.PlaceOrderFunc != nil {
+		return m.PlaceOrderFunc(ctx, req)
+	}
+	return "test-order-id", nil
+}
+
+func (m *MockExchangeClient) CancelOrder(ctx context.Context, instID, orderID string) error {
+	if m.CancelOrderFunc != nil {
+		return m.CancelOrderFunc(ctx, instID, orderID)
+	}
+	return nil
+}
+
+func (m *MockExchangeClient) CancelBatchOrders(ctx context.Context, orders []okx.CancelOrderRequest) error {
+	if m.CancelBatchOrdersFunc != nil {
+		return m.CancelBatchOrdersFunc(ctx, orders)
+	}
+	return nil
+}
+
+func (m *MockExchangeClient) GetPendingOrders(ctx context.Context, instID string) ([]okx.Order, error) {
+	if m.GetPendingOrdersFunc != nil {
+		return m.GetPendingOrdersFunc(ctx, instID)
+	}
+	return []okx.Order{}, nil
+}
+
+func (m *MockExchangeClient) GetTicker(ctx context.Context, instID string) (*okx.Ticker, error) {
+	if m.GetTickerFunc != nil {
+		return m.GetTickerFunc(ctx, instID)
+	}
+	return &okx.Ticker{Last: "2000"}, nil
+}
+
+func newTestRiskController(stopLossRatio, maxDrawdown float64) *RiskController {
+	return NewRiskController(
+		RiskParams{
+			StopLossRatio: decimal.NewFromFloat(stopLossRatio),
+			MaxDrawdown:   decimal.NewFromFloat(maxDrawdown),
+			EmergencyStop: true,
+		},
+		&MockExchangeClient{},
+		zap.NewNop(),
+	)
+}
+
+func TestShouldStopLoss(t *testing.T) {
+	tests := []struct {
+		name          string
+		stopLossRatio float64
+		initialEquity float64
+		currentEquity float64
+		expected      bool
+	}{
+		{
+			name:          "no stop loss - equity above threshold (90%)",
+			stopLossRatio: 0.2, // 20% loss threshold -> 80% equity threshold
+			initialEquity: 10000,
+			currentEquity: 9000, // 90% of initial
+			expected:      false,
+		},
+		{
+			name:          "no stop loss - exactly at threshold (80%)",
+			stopLossRatio: 0.2,
+			initialEquity: 10000,
+			currentEquity: 8000, // exactly 80%
+			expected:      false,
+		},
+		{
+			name:          "trigger stop loss - below threshold (75%)",
+			stopLossRatio: 0.2,
+			initialEquity: 10000,
+			currentEquity: 7500, // 75% < 80%
+			expected:      true,
+		},
+		{
+			name:          "trigger stop loss - significant loss (50%)",
+			stopLossRatio: 0.2,
+			initialEquity: 10000,
+			currentEquity: 5000, // 50% < 80%
+			expected:      true,
+		},
+		{
+			name:          "zero initial equity - no stop loss",
+			stopLossRatio: 0.2,
+			initialEquity: 0,
+			currentEquity: 5000,
+			expected:      false,
+		},
+		{
+			name:          "high threshold (30% loss)",
+			stopLossRatio: 0.3, // 30% loss threshold -> 70% equity
+			initialEquity: 10000,
+			currentEquity: 7500, // 75% > 70%
+			expected:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := newTestRiskController(tt.stopLossRatio, 0.5)
+
+			metrics := StrategyMetrics{
+				InitialEquity: decimal.NewFromFloat(tt.initialEquity),
+				CurrentEquity: decimal.NewFromFloat(tt.currentEquity),
+			}
+
+			result := ctrl.ShouldStopLoss(metrics)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestCheckMaxDrawdown(t *testing.T) {
+	tests := []struct {
+		name            string
+		maxDrawdown     float64
+		currentDrawdown float64
+		expected        bool
+	}{
+		{
+			name:            "within limit",
+			maxDrawdown:     0.2,
+			currentDrawdown: 0.15,
+			expected:        false,
+		},
+		{
+			name:            "at limit",
+			maxDrawdown:     0.2,
+			currentDrawdown: 0.2,
+			expected:        false,
+		},
+		{
+			name:            "exceeded",
+			maxDrawdown:     0.2,
+			currentDrawdown: 0.25,
+			expected:        true,
+		},
+		{
+			name:            "zero max drawdown - no check",
+			maxDrawdown:     0,
+			currentDrawdown: 0.5,
+			expected:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := newTestRiskController(0.2, tt.maxDrawdown)
+
+			metrics := StrategyMetrics{
+				MaxDrawdown: decimal.NewFromFloat(tt.currentDrawdown),
+			}
+
+			result := ctrl.CheckMaxDrawdown(metrics)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestCheckRisk(t *testing.T) {
+	t.Run("no risk exceeded", func(t *testing.T) {
+		ctrl := newTestRiskController(0.2, 0.3)
+		metrics := StrategyMetrics{
+			InitialEquity: decimal.NewFromFloat(10000),
+			CurrentEquity: decimal.NewFromFloat(9000),
+			MaxDrawdown:   decimal.NewFromFloat(0.1),
+		}
+
+		err := ctrl.CheckRisk(metrics)
+		assert.NoError(t, err)
+	})
+
+	t.Run("stop loss triggered", func(t *testing.T) {
+		ctrl := newTestRiskController(0.2, 0.3)
+		metrics := StrategyMetrics{
+			InitialEquity: decimal.NewFromFloat(10000),
+			CurrentEquity: decimal.NewFromFloat(7000), // 70% < 80%
+			MaxDrawdown:   decimal.NewFromFloat(0.1),
+		}
+
+		err := ctrl.CheckRisk(metrics)
+		assert.ErrorIs(t, err, ErrStopLossTriggered)
+	})
+
+	t.Run("max drawdown exceeded", func(t *testing.T) {
+		ctrl := newTestRiskController(0.2, 0.3)
+		metrics := StrategyMetrics{
+			InitialEquity: decimal.NewFromFloat(10000),
+			CurrentEquity: decimal.NewFromFloat(9000),
+			MaxDrawdown:   decimal.NewFromFloat(0.35), // > 0.3
+		}
+
+		err := ctrl.CheckRisk(metrics)
+		assert.ErrorIs(t, err, ErrMaxDrawdownExceeded)
+	})
+}
+
+func TestCalculateEquity(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("calculate with position and P&L", func(t *testing.T) {
+		mockClient := &MockExchangeClient{
+			GetBalanceFunc: func(ctx context.Context, currency string) (*okx.Balance, error) {
+				return &okx.Balance{
+					Available: "8000",
+				}, nil
+			},
+			GetPositionsFunc: func(ctx context.Context, instID string) ([]okx.Position, error) {
+				return []okx.Position{
+					{Position: "1", UnrealizedPnL: "500"},
+				}, nil
+			},
+		}
+
+		ctrl := NewRiskController(
+			RiskParams{StopLossRatio: decimal.NewFromFloat(0.2)},
+			mockClient,
+			zap.NewNop(),
+		)
+
+		peakEquity := decimal.NewFromFloat(10000)
+		maxDrawdown := decimal.Zero
+
+		update, err := ctrl.CalculateEquity(ctx, "ETH-USDT-SWAP", peakEquity, maxDrawdown)
+		require.NoError(t, err)
+
+		// 8000 + 500 = 8500
+		assert.True(t, update.CurrentEquity.Equal(decimal.NewFromFloat(8500)))
+		assert.True(t, update.UnrealizedPnL.Equal(decimal.NewFromFloat(500)))
+	})
+
+	t.Run("calculate drawdown when equity drops", func(t *testing.T) {
+		mockClient := &MockExchangeClient{
+			GetBalanceFunc: func(ctx context.Context, currency string) (*okx.Balance, error) {
+				return &okx.Balance{Available: "8000"}, nil
+			},
+			GetPositionsFunc: func(ctx context.Context, instID string) ([]okx.Position, error) {
+				return []okx.Position{}, nil
+			},
+		}
+
+		ctrl := NewRiskController(
+			RiskParams{StopLossRatio: decimal.NewFromFloat(0.2)},
+			mockClient,
+			zap.NewNop(),
+		)
+
+		peakEquity := decimal.NewFromFloat(10000)
+		maxDrawdown := decimal.Zero
+
+		update, err := ctrl.CalculateEquity(ctx, "ETH-USDT-SWAP", peakEquity, maxDrawdown)
+		require.NoError(t, err)
+
+		// Drawdown = (10000 - 8000) / 10000 = 0.2
+		assert.True(t, update.MaxDrawdown.Equal(decimal.NewFromFloat(0.2)))
+	})
+}
+
+func TestInitializeEquity(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("with no existing positions", func(t *testing.T) {
+		mockClient := &MockExchangeClient{
+			GetBalanceFunc: func(ctx context.Context, currency string) (*okx.Balance, error) {
+				return &okx.Balance{Available: "10000"}, nil
+			},
+			GetPositionsFunc: func(ctx context.Context, instID string) ([]okx.Position, error) {
+				return []okx.Position{}, nil
+			},
+		}
+
+		ctrl := NewRiskController(
+			RiskParams{},
+			mockClient,
+			zap.NewNop(),
+		)
+
+		metrics := StrategyMetrics{}
+		err := ctrl.InitializeEquity(ctx, &metrics, "ETH-USDT-SWAP")
+
+		require.NoError(t, err)
+		assert.True(t, metrics.InitialEquity.Equal(decimal.NewFromFloat(10000)))
+		assert.True(t, metrics.CurrentEquity.Equal(decimal.NewFromFloat(10000)))
+		assert.True(t, metrics.PeakEquity.Equal(decimal.NewFromFloat(10000)))
+	})
+
+	t.Run("with existing positions and unrealized PnL", func(t *testing.T) {
+		mockClient := &MockExchangeClient{
+			GetBalanceFunc: func(ctx context.Context, currency string) (*okx.Balance, error) {
+				return &okx.Balance{Available: "10000"}, nil
+			},
+			GetPositionsFunc: func(ctx context.Context, instID string) ([]okx.Position, error) {
+				return []okx.Position{
+					{Position: "1", UnrealizedPnL: "500"},
+				}, nil
+			},
+		}
+
+		ctrl := NewRiskController(
+			RiskParams{},
+			mockClient,
+			zap.NewNop(),
+		)
+
+		metrics := StrategyMetrics{}
+		err := ctrl.InitializeEquity(ctx, &metrics, "ETH-USDT-SWAP")
+
+		require.NoError(t, err)
+		// 10000 + 500 = 10500
+		assert.True(t, metrics.InitialEquity.Equal(decimal.NewFromFloat(10500)))
+		assert.True(t, metrics.CurrentEquity.Equal(decimal.NewFromFloat(10500)))
+		assert.True(t, metrics.UnrealizedPnL.Equal(decimal.NewFromFloat(500)))
+	})
+
+	t.Run("with empty instID uses balance only", func(t *testing.T) {
+		mockClient := &MockExchangeClient{
+			GetBalanceFunc: func(ctx context.Context, currency string) (*okx.Balance, error) {
+				return &okx.Balance{Available: "10000"}, nil
+			},
+		}
+
+		ctrl := NewRiskController(
+			RiskParams{},
+			mockClient,
+			zap.NewNop(),
+		)
+
+		metrics := StrategyMetrics{}
+		err := ctrl.InitializeEquity(ctx, &metrics, "")
+
+		require.NoError(t, err)
+		assert.True(t, metrics.InitialEquity.Equal(decimal.NewFromFloat(10000)))
+	})
+}
+
+func TestEmergencyClose(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("cancel orders and close positions", func(t *testing.T) {
+		cancelCalled := false
+		closeCalled := false
+
+		mockClient := &MockExchangeClient{
+			GetPendingOrdersFunc: func(ctx context.Context, instID string) ([]okx.Order, error) {
+				return []okx.Order{
+					{OrderID: "order1"},
+					{OrderID: "order2"},
+				}, nil
+			},
+			CancelBatchOrdersFunc: func(ctx context.Context, orders []okx.CancelOrderRequest) error {
+				cancelCalled = true
+				assert.Len(t, orders, 2)
+				return nil
+			},
+			GetPositionsFunc: func(ctx context.Context, instID string) ([]okx.Position, error) {
+				return []okx.Position{
+					{Position: "1"},
+				}, nil
+			},
+			PlaceOrderFunc: func(ctx context.Context, req *okx.OrderRequest) (string, error) {
+				closeCalled = true
+				assert.Equal(t, "sell", req.Side) // Long position -> sell
+				assert.Equal(t, "market", req.OrderType)
+				assert.True(t, req.ReduceOnly)
+				return "close-order-id", nil
+			},
+		}
+
+		ctrl := NewRiskController(RiskParams{}, mockClient, zap.NewNop())
+		err := ctrl.EmergencyClose(ctx, "ETH-USDT-SWAP", TradeModeCross)
+
+		require.NoError(t, err)
+		assert.True(t, cancelCalled)
+		assert.True(t, closeCalled)
+	})
+
+	t.Run("close short position", func(t *testing.T) {
+		mockClient := &MockExchangeClient{
+			GetPendingOrdersFunc: func(ctx context.Context, instID string) ([]okx.Order, error) {
+				return []okx.Order{}, nil
+			},
+			GetPositionsFunc: func(ctx context.Context, instID string) ([]okx.Position, error) {
+				return []okx.Position{
+					{Position: "-1"}, // Short position
+				}, nil
+			},
+			PlaceOrderFunc: func(ctx context.Context, req *okx.OrderRequest) (string, error) {
+				assert.Equal(t, "buy", req.Side) // Short position -> buy to close
+				return "close-order-id", nil
+			},
+		}
+
+		ctrl := NewRiskController(RiskParams{}, mockClient, zap.NewNop())
+		err := ctrl.EmergencyClose(ctx, "ETH-USDT-SWAP", TradeModeCross)
+
+		require.NoError(t, err)
+	})
+}
+
+func TestHasOpenPosition(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("has position", func(t *testing.T) {
+		mockClient := &MockExchangeClient{
+			GetPositionsFunc: func(ctx context.Context, instID string) ([]okx.Position, error) {
+				return []okx.Position{
+					{Position: "1.5"},
+				}, nil
+			},
+		}
+
+		ctrl := NewRiskController(RiskParams{}, mockClient, zap.NewNop())
+		hasPos, size, err := ctrl.HasOpenPosition(ctx, "ETH-USDT-SWAP")
+
+		require.NoError(t, err)
+		assert.True(t, hasPos)
+		assert.True(t, size.Equal(decimal.NewFromFloat(1.5)))
+	})
+
+	t.Run("no position", func(t *testing.T) {
+		mockClient := &MockExchangeClient{
+			GetPositionsFunc: func(ctx context.Context, instID string) ([]okx.Position, error) {
+				return []okx.Position{}, nil
+			},
+		}
+
+		ctrl := NewRiskController(RiskParams{}, mockClient, zap.NewNop())
+		hasPos, size, err := ctrl.HasOpenPosition(ctx, "ETH-USDT-SWAP")
+
+		require.NoError(t, err)
+		assert.False(t, hasPos)
+		assert.True(t, size.IsZero())
+	})
+}

--- a/internal/strategy/grid/strategy.go
+++ b/internal/strategy/grid/strategy.go
@@ -1,0 +1,771 @@
+package grid
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"grid-trading-bot/internal/okx"
+
+	"github.com/shopspring/decimal"
+	"go.uber.org/zap"
+)
+
+// Default configuration constants (kept for backwards compatibility)
+const (
+	DefaultRiskCheckInterval = 30 * time.Second // Default interval for risk checks
+	DefaultRebuildTimeout    = 30 * time.Second // Default timeout for grid rebuild operations
+)
+
+// Functional options for StrategyManager
+type StrategyOption func(*StrategyManager)
+
+// WithConfig sets custom configuration for the strategy manager
+func WithConfig(config StrategyConfig) StrategyOption {
+	return func(m *StrategyManager) {
+		config.Validate()
+		m.config = config
+	}
+}
+
+// WSClient defines the WebSocket client interface
+type WSClient interface {
+	ConnectPublic(ctx context.Context) error
+	ConnectPrivate(ctx context.Context) error
+	SubscribeTicker(instID string) error
+	SubscribeOrders(instID string) error
+	SetTickerHandler(handler func(ticker *okx.WSTicker))
+	SetOrderHandler(handler func(order *okx.WSOrder))
+	SetConnectedHandler(handler func(channelType string))
+	SetDisconnectedHandler(handler func(channelType string, err error))
+	IsPublicConnected() bool
+	IsPrivateConnected() bool
+	Disconnect()
+}
+
+// StrategyManager manages the grid trading strategy lifecycle
+type StrategyManager struct {
+	restClient ExchangeClient
+	wsClient   WSClient
+	logger     *zap.Logger
+	config     StrategyConfig
+
+	strategy   *Strategy
+	calculator *Calculator
+	orderMgr   *OrderManager
+	riskCtrl   *RiskController
+
+	// Control channels
+	stopChan chan struct{}
+	doneChan chan struct{}
+
+	// Atomic flag to prevent concurrent grid rebuilds
+	rebuilding int32
+
+	mu sync.RWMutex
+}
+
+// NewStrategyManager creates a new strategy manager
+// Options can be passed to customize the configuration using WithConfig()
+func NewStrategyManager(
+	restClient ExchangeClient,
+	wsClient WSClient,
+	logger *zap.Logger,
+	opts ...StrategyOption,
+) *StrategyManager {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+
+	m := &StrategyManager{
+		restClient: restClient,
+		wsClient:   wsClient,
+		logger:     logger,
+		config:     DefaultStrategyConfig(),
+	}
+
+	// Apply options
+	for _, opt := range opts {
+		opt(m)
+	}
+
+	// Initialize calculator with config
+	m.calculator = NewCalculatorWithPrecision(logger, m.config.OrderPrecision)
+
+	return m
+}
+
+// Start starts the grid trading strategy
+func (m *StrategyManager) Start(ctx context.Context, params GridParams, riskParams RiskParams) error {
+	m.mu.Lock()
+	if m.strategy != nil && m.strategy.IsRunning() {
+		m.mu.Unlock()
+		return ErrStrategyAlreadyRunning
+	}
+	m.mu.Unlock()
+
+	m.logger.Info("Starting grid strategy",
+		zap.String("instId", params.InstID),
+		zap.String("lowerBound", params.LowerBound.String()),
+		zap.String("upperBound", params.UpperBound.String()),
+		zap.Int("gridCount", params.GridCount))
+
+	// Step 1: Validate parameters
+	if err := m.validateParams(params); err != nil {
+		return err
+	}
+
+	// Step 2: Get current market price
+	ticker, err := m.restClient.GetTicker(ctx, params.InstID)
+	if err != nil {
+		return WrapError("GetTicker", err)
+	}
+
+	currentPrice, err := decimal.NewFromString(ticker.Last)
+	if err != nil {
+		return WrapError("ParsePrice", err)
+	}
+
+	m.logger.Info("Current market price", zap.String("price", currentPrice.String()))
+
+	// Step 3: Calculate grid levels
+	levels, err := m.calculator.CalculateGridLevels(params)
+	if err != nil {
+		return err
+	}
+
+	// Step 4: Calculate order size
+	orderSize := m.calculator.CalculateOrderSize(params, currentPrice)
+	if orderSize.IsZero() {
+		return NewStrategyError("CalculateOrderSize", ErrInvalidParams, map[string]interface{}{
+			"reason": "calculated order size is zero",
+		})
+	}
+
+	// Step 5: Create strategy instance
+	strategyID := generateStrategyID()
+	m.mu.Lock()
+	m.strategy = NewStrategy(strategyID, params, riskParams)
+	m.strategy.Levels = levels
+	m.strategy.OrderSize = orderSize
+	m.strategy.SetStartTime(time.Now())
+	m.mu.Unlock()
+
+	// Step 6: Initialize risk controller
+	m.riskCtrl = NewRiskControllerWithCurrency(riskParams, m.restClient, m.logger, m.config.QuoteCurrency)
+	if err := m.riskCtrl.InitializeEquity(ctx, &m.strategy.Metrics, params.InstID); err != nil {
+		return err
+	}
+
+	// Step 7: Initialize order manager
+	m.orderMgr = NewOrderManager(m.restClient, m.calculator, m.logger)
+
+	// Step 8: Setup WebSocket connections
+	if err := m.setupWebSocket(ctx, params.InstID); err != nil {
+		return err
+	}
+
+	// Step 9: Place initial orders
+	if err := m.orderMgr.PlaceInitialOrders(ctx, m.strategy, currentPrice); err != nil {
+		// Partial failure is a warning, not a fatal error
+		if errors.Is(err, ErrOrderPartialFailure) {
+			m.logger.Warn("Some initial orders failed to place", zap.Error(err))
+		} else {
+			return err
+		}
+	}
+
+	// Step 10: Start background tasks
+	m.stopChan = make(chan struct{})
+	m.doneChan = make(chan struct{})
+	go m.runRiskCheckLoop()
+
+	// Set state to running
+	m.strategy.SetState(StateRunning)
+
+	m.logger.Info("Grid strategy started",
+		zap.String("strategyId", strategyID),
+		zap.String("orderSize", orderSize.String()),
+		zap.Int("orderCount", m.orderMgr.GetActiveOrderCount(m.strategy)))
+
+	return nil
+}
+
+// Stop stops the grid trading strategy
+func (m *StrategyManager) Stop(ctx context.Context) error {
+	m.mu.Lock()
+	if m.strategy == nil {
+		m.mu.Unlock()
+		return ErrStrategyNotRunning
+	}
+
+	if m.strategy.GetState() == StateStopping || m.strategy.GetState() == StateStopped {
+		m.mu.Unlock()
+		return ErrStrategyStopping
+	}
+
+	m.strategy.SetState(StateStopping)
+	m.mu.Unlock()
+
+	m.logger.Info("Stopping grid strategy")
+
+	// Signal background tasks to stop
+	close(m.stopChan)
+
+	// Wait for background tasks with timeout
+	select {
+	case <-m.doneChan:
+	case <-time.After(10 * time.Second):
+		m.logger.Warn("Timeout waiting for background tasks")
+	}
+
+	// Cancel all pending orders
+	if err := m.orderMgr.CancelAllOrders(ctx, m.strategy); err != nil {
+		m.logger.Error("Failed to cancel orders", zap.Error(err))
+	}
+
+	// Disconnect WebSocket
+	if m.wsClient != nil {
+		m.wsClient.Disconnect()
+	}
+
+	m.strategy.SetState(StateStopped)
+	m.strategy.SetStopTime(time.Now())
+
+	m.logger.Info("Grid strategy stopped",
+		zap.String("strategyId", m.strategy.ID),
+		zap.Int("totalTrades", m.strategy.Metrics.TotalTrades))
+
+	return nil
+}
+
+// EmergencyStop performs emergency stop with position closure
+func (m *StrategyManager) EmergencyStop(ctx context.Context) error {
+	m.mu.Lock()
+	if m.strategy == nil {
+		m.mu.Unlock()
+		return ErrStrategyNotRunning
+	}
+	m.strategy.SetState(StateEmergency)
+	m.mu.Unlock()
+
+	m.logger.Warn("Emergency stop triggered")
+
+	// Signal background tasks
+	select {
+	case <-m.stopChan:
+	default:
+		close(m.stopChan)
+	}
+
+	// Emergency close through risk controller
+	if m.riskCtrl != nil {
+		if err := m.riskCtrl.EmergencyClose(ctx, m.strategy.Params.InstID, m.strategy.Params.TradeMode); err != nil {
+			m.logger.Error("Emergency close failed", zap.Error(err))
+			return err
+		}
+	}
+
+	// Disconnect WebSocket
+	if m.wsClient != nil {
+		m.wsClient.Disconnect()
+	}
+
+	m.strategy.SetStopTime(time.Now())
+
+	m.logger.Info("Emergency stop completed")
+
+	return nil
+}
+
+// GetStatus returns the current strategy status
+func (m *StrategyManager) GetStatus() *StrategyStatus {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if m.strategy == nil {
+		return &StrategyStatus{State: StateIdle}
+	}
+
+	return &StrategyStatus{
+		ID:           m.strategy.ID,
+		State:        m.strategy.GetState(),
+		Params:       m.strategy.Params,
+		Metrics:      m.strategy.GetMetrics(),
+		ActiveOrders: m.orderMgr.GetActiveOrderCount(m.strategy),
+		StartTime:    m.strategy.GetStartTime(),
+	}
+}
+
+// GetMetrics returns the current strategy metrics
+func (m *StrategyManager) GetMetrics() StrategyMetrics {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if m.strategy == nil {
+		return StrategyMetrics{}
+	}
+
+	return m.strategy.GetMetrics()
+}
+
+// StrategyStatus represents the current strategy status
+type StrategyStatus struct {
+	ID           string
+	State        StrategyState
+	Params       GridParams
+	Metrics      StrategyMetrics
+	ActiveOrders int
+	StartTime    time.Time
+}
+
+// setupWebSocket sets up WebSocket connections and handlers
+func (m *StrategyManager) setupWebSocket(ctx context.Context, instID string) error {
+	// Set handlers before connecting
+	m.wsClient.SetTickerHandler(m.handleTickerUpdate)
+	m.wsClient.SetOrderHandler(m.handleOrderUpdate)
+	m.wsClient.SetConnectedHandler(m.handleConnected)
+	m.wsClient.SetDisconnectedHandler(m.handleDisconnected)
+
+	// Connect to public channel for ticker
+	if err := m.wsClient.ConnectPublic(ctx); err != nil {
+		return WrapError("ConnectPublic", err)
+	}
+
+	// Connect to private channel for orders
+	if err := m.wsClient.ConnectPrivate(ctx); err != nil {
+		return WrapError("ConnectPrivate", err)
+	}
+
+	// Subscribe to ticker
+	if err := m.wsClient.SubscribeTicker(instID); err != nil {
+		return WrapError("SubscribeTicker", err)
+	}
+
+	// Subscribe to orders
+	if err := m.wsClient.SubscribeOrders(instID); err != nil {
+		return WrapError("SubscribeOrders", err)
+	}
+
+	m.logger.Info("WebSocket setup completed", zap.String("instId", instID))
+
+	return nil
+}
+
+// handleTickerUpdate processes ticker updates from WebSocket
+func (m *StrategyManager) handleTickerUpdate(ticker *okx.WSTicker) {
+	m.mu.RLock()
+	strategy := m.strategy
+	m.mu.RUnlock()
+
+	if strategy == nil || !strategy.IsRunning() {
+		return
+	}
+
+	lastPrice, err := decimal.NewFromString(ticker.Last)
+	if err != nil {
+		m.logger.Warn("Failed to parse ticker price", zap.Error(err))
+		return
+	}
+
+	// Update last price
+	strategy.UpdateMetrics(func(metrics *StrategyMetrics) {
+		metrics.LastPrice = lastPrice
+		metrics.UpdateTime = time.Now()
+	})
+
+	// Check if grid rebuild is needed
+	if m.calculator.NeedRebuild(strategy.Levels, lastPrice) {
+		// Use atomic flag to prevent concurrent rebuilds
+		if !atomic.CompareAndSwapInt32(&m.rebuilding, 0, 1) {
+			m.logger.Debug("Grid rebuild already in progress, skipping")
+			return
+		}
+
+		m.logger.Info("Price breakout detected, rebuilding grid",
+			zap.String("price", lastPrice.String()))
+
+		go func() {
+			defer atomic.StoreInt32(&m.rebuilding, 0)
+
+			ctx, cancel := context.WithTimeout(context.Background(), m.config.RebuildTimeout)
+			defer cancel()
+
+			if err := m.rebuildGrid(ctx, lastPrice); err != nil {
+				m.logger.Error("Failed to rebuild grid", zap.Error(err))
+			}
+		}()
+	}
+}
+
+// handleOrderUpdate processes order updates from WebSocket
+func (m *StrategyManager) handleOrderUpdate(order *okx.WSOrder) {
+	m.mu.RLock()
+	strategy := m.strategy
+	m.mu.RUnlock()
+
+	if strategy == nil || !strategy.IsRunning() {
+		return
+	}
+
+	m.logger.Debug("Order update received",
+		zap.String("orderId", order.OrderID),
+		zap.String("state", order.State),
+		zap.String("side", order.Side))
+
+	switch order.State {
+	case "filled":
+		m.handleOrderFilled(order)
+	case "canceled":
+		m.handleOrderCanceled(order)
+	case "partially_filled":
+		m.handlePartiallyFilled(order)
+	}
+}
+
+// handleOrderFilled processes filled orders
+func (m *StrategyManager) handleOrderFilled(order *okx.WSOrder) {
+	m.mu.RLock()
+	strategy := m.strategy
+	m.mu.RUnlock()
+
+	if strategy == nil {
+		return
+	}
+
+	filledPrice, _ := decimal.NewFromString(order.FillPrice)
+	filledSize, _ := decimal.NewFromString(order.AccFillSize)
+
+	ctx := context.Background()
+
+	if err := m.orderMgr.HandleOrderFilled(ctx, strategy, order.OrderID, filledPrice, filledSize); err != nil {
+		if !errors.Is(err, ErrOrderNotFound) {
+			m.logger.Error("Failed to handle filled order",
+				zap.String("orderId", order.OrderID),
+				zap.Error(err))
+		}
+	}
+
+	// Check risk after trade
+	go func() {
+		if err := m.checkRiskAndUpdate(ctx); err != nil {
+			m.logger.Error("Risk check failed after trade", zap.Error(err))
+		}
+	}()
+}
+
+// handleOrderCanceled processes canceled orders
+func (m *StrategyManager) handleOrderCanceled(order *okx.WSOrder) {
+	m.mu.RLock()
+	strategy := m.strategy
+	m.mu.RUnlock()
+
+	if strategy == nil {
+		return
+	}
+
+	strategy.RemoveOrder(order.OrderID)
+
+	m.logger.Debug("Order canceled",
+		zap.String("orderId", order.OrderID))
+}
+
+// handlePartiallyFilled processes partially filled orders
+func (m *StrategyManager) handlePartiallyFilled(order *okx.WSOrder) {
+	m.mu.RLock()
+	strategy := m.strategy
+	m.mu.RUnlock()
+
+	if strategy == nil {
+		return
+	}
+
+	gridOrder, ok := strategy.GetOrder(order.OrderID)
+	if !ok {
+		return
+	}
+
+	filledSize, _ := decimal.NewFromString(order.AccFillSize)
+	gridOrder.FilledSize = filledSize
+	gridOrder.UpdateTime = time.Now()
+
+	m.logger.Debug("Order partially filled",
+		zap.String("orderId", order.OrderID),
+		zap.String("filledSize", filledSize.String()))
+}
+
+// handleConnected handles WebSocket connection events
+func (m *StrategyManager) handleConnected(channelType string) {
+	m.logger.Info("WebSocket connected", zap.String("channel", channelType))
+}
+
+// handleDisconnected handles WebSocket disconnection events
+func (m *StrategyManager) handleDisconnected(channelType string, err error) {
+	m.logger.Warn("WebSocket disconnected",
+		zap.String("channel", channelType),
+		zap.Error(err))
+
+	// Attempt automatic reconnection if enabled
+	if m.config.EnableAutoReconnect {
+		go m.attemptReconnect(channelType)
+	}
+}
+
+// attemptReconnect attempts to reconnect WebSocket with exponential backoff
+func (m *StrategyManager) attemptReconnect(channelType string) {
+	m.mu.RLock()
+	strategy := m.strategy
+	m.mu.RUnlock()
+
+	// Don't reconnect if strategy is not running
+	if strategy == nil || !strategy.IsRunning() {
+		m.logger.Debug("Skipping reconnection - strategy not running")
+		return
+	}
+
+	instID := strategy.Params.InstID
+	attempt := 0
+	delay := m.config.ReconnectBaseDelay
+
+	for {
+		// Check if strategy is still running
+		m.mu.RLock()
+		strategy = m.strategy
+		m.mu.RUnlock()
+
+		if strategy == nil || !strategy.IsRunning() {
+			m.logger.Debug("Stopping reconnection - strategy no longer running")
+			return
+		}
+
+		// Check max attempts
+		if m.config.ReconnectMaxAttempts > 0 && attempt >= m.config.ReconnectMaxAttempts {
+			m.logger.Error("WebSocket reconnection failed - max attempts reached",
+				zap.String("channel", channelType),
+				zap.Int("attempts", attempt))
+
+			// Call the failure callback if configured
+			if m.config.OnReconnectFailed != nil {
+				m.config.OnReconnectFailed(channelType, attempt)
+			}
+
+			// Trigger emergency stop if configured
+			if m.config.EmergencyStopOnFailure {
+				m.logger.Warn("Triggering emergency stop due to reconnection failure")
+				go func() {
+					if err := m.EmergencyStop(context.Background()); err != nil {
+						m.logger.Error("Failed to execute emergency stop", zap.Error(err))
+					}
+				}()
+			}
+
+			return
+		}
+
+		attempt++
+		m.logger.Info("Attempting WebSocket reconnection",
+			zap.String("channel", channelType),
+			zap.Int("attempt", attempt),
+			zap.Duration("delay", delay))
+
+		// Wait before reconnecting
+		select {
+		case <-m.stopChan:
+			m.logger.Debug("Reconnection cancelled - strategy stopping")
+			return
+		case <-time.After(delay):
+		}
+
+		// Attempt reconnection
+		ctx, cancel := context.WithTimeout(context.Background(), m.config.ReconnectTimeout)
+		var reconnectErr error
+
+		if channelType == "public" {
+			reconnectErr = m.wsClient.ConnectPublic(ctx)
+			if reconnectErr == nil {
+				reconnectErr = m.wsClient.SubscribeTicker(instID)
+			}
+		} else if channelType == "private" {
+			reconnectErr = m.wsClient.ConnectPrivate(ctx)
+			if reconnectErr == nil {
+				reconnectErr = m.wsClient.SubscribeOrders(instID)
+			}
+		}
+		cancel()
+
+		if reconnectErr == nil {
+			m.logger.Info("WebSocket reconnection successful",
+				zap.String("channel", channelType),
+				zap.Int("attempts", attempt))
+			return
+		}
+
+		m.logger.Warn("WebSocket reconnection failed, will retry",
+			zap.String("channel", channelType),
+			zap.Int("attempt", attempt),
+			zap.Error(reconnectErr))
+
+		// Exponential backoff with max delay
+		delay = delay * 2
+		if delay > m.config.ReconnectMaxDelay {
+			delay = m.config.ReconnectMaxDelay
+		}
+	}
+}
+
+// rebuildGrid rebuilds the grid after price breakout
+func (m *StrategyManager) rebuildGrid(ctx context.Context, currentPrice decimal.Decimal) error {
+	m.mu.Lock()
+	strategy := m.strategy
+	if strategy == nil || !strategy.IsRunning() {
+		m.mu.Unlock()
+		return ErrStrategyNotRunning
+	}
+	m.mu.Unlock()
+
+	m.logger.Info("Rebuilding grid",
+		zap.String("currentPrice", currentPrice.String()))
+
+	// Cancel all existing orders
+	if err := m.orderMgr.CancelAllOrders(ctx, strategy); err != nil {
+		return err
+	}
+
+	// Close any open positions
+	if m.riskCtrl != nil {
+		hasPos, posSize, err := m.riskCtrl.HasOpenPosition(ctx, strategy.Params.InstID)
+		if err != nil {
+			m.logger.Warn("Failed to check position", zap.Error(err))
+		} else if hasPos {
+			m.logger.Info("Closing position before grid rebuild",
+				zap.String("size", posSize.String()))
+			if err := m.riskCtrl.EmergencyClose(ctx, strategy.Params.InstID, strategy.Params.TradeMode); err != nil {
+				return WrapError("ClosePosition", err)
+			}
+		}
+	}
+
+	// Calculate new grid
+	newLevels, newParams, err := m.calculator.RebuildGrid(strategy.Params, currentPrice)
+	if err != nil {
+		return err
+	}
+
+	// Update strategy
+	m.mu.Lock()
+	strategy.Levels = newLevels
+	strategy.Params = newParams
+	strategy.Orders = make(map[string]*GridOrder)
+	m.mu.Unlock()
+
+	// Place new orders
+	if err := m.orderMgr.PlaceInitialOrders(ctx, strategy, currentPrice); err != nil {
+		return err
+	}
+
+	m.logger.Info("Grid rebuild completed",
+		zap.String("newLower", newParams.LowerBound.String()),
+		zap.String("newUpper", newParams.UpperBound.String()))
+
+	return nil
+}
+
+// runRiskCheckLoop runs periodic risk checks
+func (m *StrategyManager) runRiskCheckLoop() {
+	defer close(m.doneChan)
+
+	ticker := time.NewTicker(m.config.RiskCheckInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-m.stopChan:
+			return
+		case <-ticker.C:
+			ctx := context.Background()
+			if err := m.checkRiskAndUpdate(ctx); err != nil {
+				if IsFatal(err) {
+					m.logger.Error("Fatal risk condition detected", zap.Error(err))
+					_ = m.EmergencyStop(ctx)
+					return
+				}
+				m.logger.Warn("Risk check warning", zap.Error(err))
+			}
+		}
+	}
+}
+
+// checkRiskAndUpdate performs risk check and updates metrics
+func (m *StrategyManager) checkRiskAndUpdate(ctx context.Context) error {
+	m.mu.RLock()
+	strategy := m.strategy
+	riskCtrl := m.riskCtrl
+	m.mu.RUnlock()
+
+	if strategy == nil || riskCtrl == nil || !strategy.IsRunning() {
+		return nil
+	}
+
+	// Get current metrics for calculation (thread-safe read)
+	currentMetrics := strategy.GetMetrics()
+
+	// Calculate equity without modifying state
+	equityUpdate, err := riskCtrl.CalculateEquity(
+		ctx,
+		strategy.Params.InstID,
+		currentMetrics.PeakEquity,
+		currentMetrics.MaxDrawdown,
+	)
+	if err != nil {
+		return err
+	}
+
+	// Apply update through thread-safe method
+	strategy.UpdateMetrics(func(m *StrategyMetrics) {
+		m.CurrentEquity = equityUpdate.CurrentEquity
+		m.UnrealizedPnL = equityUpdate.UnrealizedPnL
+		m.PeakEquity = equityUpdate.PeakEquity
+		m.MaxDrawdown = equityUpdate.MaxDrawdown
+		m.UpdateTime = time.Now()
+	})
+
+	// Check risk limits
+	return riskCtrl.CheckRisk(strategy.GetMetrics())
+}
+
+// validateParams validates strategy parameters
+func (m *StrategyManager) validateParams(params GridParams) error {
+	if params.InstID == "" {
+		return NewStrategyError("validateParams", ErrInvalidParams, map[string]interface{}{
+			"reason": "instID is required",
+		})
+	}
+
+	if params.GridCount <= 0 {
+		return NewStrategyError("validateParams", ErrInvalidParams, map[string]interface{}{
+			"reason": "gridCount must be positive",
+		})
+	}
+
+	if params.TotalInvestment.LessThanOrEqual(decimal.Zero) {
+		return NewStrategyError("validateParams", ErrInvalidParams, map[string]interface{}{
+			"reason": "totalInvestment must be positive",
+		})
+	}
+
+	if !params.TradeMode.IsValid() {
+		return NewStrategyError("validateParams", ErrInvalidParams, map[string]interface{}{
+			"reason":    "tradeMode must be 'cross' or 'isolated'",
+			"tradeMode": params.TradeMode.String(),
+		})
+	}
+
+	return nil
+}
+
+// generateStrategyID generates a unique strategy ID
+func generateStrategyID() string {
+	return time.Now().Format("20060102150405")
+}

--- a/internal/strategy/grid/strategy_test.go
+++ b/internal/strategy/grid/strategy_test.go
@@ -1,0 +1,680 @@
+package grid
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"grid-trading-bot/internal/okx"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// MockWSClient implements WSClient for testing
+type MockWSClient struct {
+	ConnectPublicFunc          func(ctx context.Context) error
+	ConnectPrivateFunc         func(ctx context.Context) error
+	SubscribeTickerFunc        func(instID string) error
+	SubscribeOrdersFunc        func(instID string) error
+	SetTickerHandlerFunc       func(handler func(ticker *okx.WSTicker))
+	SetOrderHandlerFunc        func(handler func(order *okx.WSOrder))
+	SetConnectedHandlerFunc    func(handler func(channelType string))
+	SetDisconnectedHandlerFunc func(handler func(channelType string, err error))
+	IsPublicConnectedFunc      func() bool
+	IsPrivateConnectedFunc     func() bool
+	DisconnectFunc             func()
+
+	// Store handlers for testing
+	tickerHandler       func(ticker *okx.WSTicker)
+	orderHandler        func(order *okx.WSOrder)
+	connectedHandler    func(channelType string)
+	disconnectedHandler func(channelType string, err error)
+}
+
+func (m *MockWSClient) ConnectPublic(ctx context.Context) error {
+	if m.ConnectPublicFunc != nil {
+		return m.ConnectPublicFunc(ctx)
+	}
+	return nil
+}
+
+func (m *MockWSClient) ConnectPrivate(ctx context.Context) error {
+	if m.ConnectPrivateFunc != nil {
+		return m.ConnectPrivateFunc(ctx)
+	}
+	return nil
+}
+
+func (m *MockWSClient) SubscribeTicker(instID string) error {
+	if m.SubscribeTickerFunc != nil {
+		return m.SubscribeTickerFunc(instID)
+	}
+	return nil
+}
+
+func (m *MockWSClient) SubscribeOrders(instID string) error {
+	if m.SubscribeOrdersFunc != nil {
+		return m.SubscribeOrdersFunc(instID)
+	}
+	return nil
+}
+
+func (m *MockWSClient) SetTickerHandler(handler func(ticker *okx.WSTicker)) {
+	m.tickerHandler = handler
+	if m.SetTickerHandlerFunc != nil {
+		m.SetTickerHandlerFunc(handler)
+	}
+}
+
+func (m *MockWSClient) SetOrderHandler(handler func(order *okx.WSOrder)) {
+	m.orderHandler = handler
+	if m.SetOrderHandlerFunc != nil {
+		m.SetOrderHandlerFunc(handler)
+	}
+}
+
+func (m *MockWSClient) SetConnectedHandler(handler func(channelType string)) {
+	m.connectedHandler = handler
+	if m.SetConnectedHandlerFunc != nil {
+		m.SetConnectedHandlerFunc(handler)
+	}
+}
+
+func (m *MockWSClient) SetDisconnectedHandler(handler func(channelType string, err error)) {
+	m.disconnectedHandler = handler
+	if m.SetDisconnectedHandlerFunc != nil {
+		m.SetDisconnectedHandlerFunc(handler)
+	}
+}
+
+func (m *MockWSClient) IsPublicConnected() bool {
+	if m.IsPublicConnectedFunc != nil {
+		return m.IsPublicConnectedFunc()
+	}
+	return true
+}
+
+func (m *MockWSClient) IsPrivateConnected() bool {
+	if m.IsPrivateConnectedFunc != nil {
+		return m.IsPrivateConnectedFunc()
+	}
+	return true
+}
+
+func (m *MockWSClient) Disconnect() {
+	if m.DisconnectFunc != nil {
+		m.DisconnectFunc()
+	}
+}
+
+// SimulateTicker simulates a ticker update
+func (m *MockWSClient) SimulateTicker(ticker *okx.WSTicker) {
+	if m.tickerHandler != nil {
+		m.tickerHandler(ticker)
+	}
+}
+
+// SimulateOrder simulates an order update
+func (m *MockWSClient) SimulateOrder(order *okx.WSOrder) {
+	if m.orderHandler != nil {
+		m.orderHandler(order)
+	}
+}
+
+func newTestStrategyManager() (*StrategyManager, *MockExchangeClient, *MockWSClient) {
+	mockRest := &MockExchangeClient{
+		GetTickerFunc: func(ctx context.Context, instID string) (*okx.Ticker, error) {
+			return &okx.Ticker{Last: "2250"}, nil
+		},
+		GetBalanceFunc: func(ctx context.Context, currency string) (*okx.Balance, error) {
+			return &okx.Balance{Available: "10000"}, nil
+		},
+		GetPositionsFunc: func(ctx context.Context, instID string) ([]okx.Position, error) {
+			return []okx.Position{}, nil
+		},
+		PlaceOrderFunc: func(ctx context.Context, req *okx.OrderRequest) (string, error) {
+			return "order-" + req.Price, nil
+		},
+		GetPendingOrdersFunc: func(ctx context.Context, instID string) ([]okx.Order, error) {
+			return []okx.Order{}, nil
+		},
+	}
+
+	mockWS := &MockWSClient{}
+
+	manager := NewStrategyManager(mockRest, mockWS, zap.NewNop())
+	return manager, mockRest, mockWS
+}
+
+func TestStrategyManager_Start(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("successful start", func(t *testing.T) {
+		manager, _, _ := newTestStrategyManager()
+
+		params := GridParams{
+			InstID:          "ETH-USDT-SWAP",
+			LowerBound:      decimal.NewFromInt(2000),
+			UpperBound:      decimal.NewFromInt(2500),
+			GridCount:       5,
+			TotalInvestment: decimal.NewFromInt(10000),
+			Leverage:        10,
+			TradeMode:       TradeModeCross,
+		}
+
+		riskParams := RiskParams{
+			StopLossRatio: decimal.NewFromFloat(0.2),
+			MaxDrawdown:   decimal.NewFromFloat(0.3),
+			EmergencyStop: true,
+		}
+
+		err := manager.Start(ctx, params, riskParams)
+		require.NoError(t, err)
+
+		status := manager.GetStatus()
+		assert.Equal(t, StateRunning, status.State)
+		assert.Equal(t, "ETH-USDT-SWAP", status.Params.InstID)
+		assert.Greater(t, status.ActiveOrders, 0)
+
+		// Clean up
+		_ = manager.Stop(ctx)
+	})
+
+	t.Run("start twice returns error", func(t *testing.T) {
+		manager, _, _ := newTestStrategyManager()
+
+		params := GridParams{
+			InstID:          "ETH-USDT-SWAP",
+			LowerBound:      decimal.NewFromInt(2000),
+			UpperBound:      decimal.NewFromInt(2500),
+			GridCount:       5,
+			TotalInvestment: decimal.NewFromInt(10000),
+			Leverage:        10,
+			TradeMode:       TradeModeCross,
+		}
+
+		err := manager.Start(ctx, params, RiskParams{})
+		require.NoError(t, err)
+
+		// Try to start again
+		err = manager.Start(ctx, params, RiskParams{})
+		assert.ErrorIs(t, err, ErrStrategyAlreadyRunning)
+
+		// Clean up
+		_ = manager.Stop(ctx)
+	})
+
+	t.Run("invalid params returns error", func(t *testing.T) {
+		manager, _, _ := newTestStrategyManager()
+
+		params := GridParams{
+			InstID:    "", // Invalid - empty
+			GridCount: 5,
+		}
+
+		err := manager.Start(ctx, params, RiskParams{})
+		assert.Error(t, err)
+	})
+}
+
+func TestStrategyManager_Stop(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("successful stop", func(t *testing.T) {
+		disconnectCalled := false
+
+		manager, _, mockWS := newTestStrategyManager()
+		mockWS.DisconnectFunc = func() {
+			disconnectCalled = true
+		}
+
+		params := GridParams{
+			InstID:          "ETH-USDT-SWAP",
+			LowerBound:      decimal.NewFromInt(2000),
+			UpperBound:      decimal.NewFromInt(2500),
+			GridCount:       5,
+			TotalInvestment: decimal.NewFromInt(10000),
+			Leverage:        10,
+			TradeMode:       TradeModeCross,
+		}
+
+		err := manager.Start(ctx, params, RiskParams{})
+		require.NoError(t, err)
+
+		err = manager.Stop(ctx)
+		require.NoError(t, err)
+
+		status := manager.GetStatus()
+		assert.Equal(t, StateStopped, status.State)
+		assert.True(t, disconnectCalled)
+	})
+
+	t.Run("stop without start returns error", func(t *testing.T) {
+		manager, _, _ := newTestStrategyManager()
+
+		err := manager.Stop(ctx)
+		assert.ErrorIs(t, err, ErrStrategyNotRunning)
+	})
+}
+
+func TestStrategyManager_HandleTickerUpdate(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("updates last price", func(t *testing.T) {
+		manager, _, mockWS := newTestStrategyManager()
+
+		params := GridParams{
+			InstID:          "ETH-USDT-SWAP",
+			LowerBound:      decimal.NewFromInt(2000),
+			UpperBound:      decimal.NewFromInt(2500),
+			GridCount:       5,
+			TotalInvestment: decimal.NewFromInt(10000),
+			Leverage:        10,
+			TradeMode:       TradeModeCross,
+		}
+
+		err := manager.Start(ctx, params, RiskParams{})
+		require.NoError(t, err)
+
+		// Simulate ticker update
+		mockWS.SimulateTicker(&okx.WSTicker{
+			InstID: "ETH-USDT-SWAP",
+			Last:   "2300",
+		})
+
+		// Give some time for async processing
+		time.Sleep(50 * time.Millisecond)
+
+		metrics := manager.GetMetrics()
+		assert.True(t, metrics.LastPrice.Equal(decimal.NewFromInt(2300)))
+
+		_ = manager.Stop(ctx)
+	})
+}
+
+func TestStrategyManager_HandleOrderFilled(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("places opposite order on fill", func(t *testing.T) {
+		oppositeOrderPlaced := false
+
+		manager, mockRest, mockWS := newTestStrategyManager()
+		mockRest.PlaceOrderFunc = func(ctx context.Context, req *okx.OrderRequest) (string, error) {
+			if req.Side == "sell" {
+				oppositeOrderPlaced = true
+			}
+			return "order-" + req.Price, nil
+		}
+
+		params := GridParams{
+			InstID:          "ETH-USDT-SWAP",
+			LowerBound:      decimal.NewFromInt(2000),
+			UpperBound:      decimal.NewFromInt(2500),
+			GridCount:       5,
+			TotalInvestment: decimal.NewFromInt(10000),
+			Leverage:        10,
+			TradeMode:       TradeModeCross,
+		}
+
+		err := manager.Start(ctx, params, RiskParams{})
+		require.NoError(t, err)
+
+		// Get one of the buy orders
+		var buyOrderID string
+		for orderID, order := range manager.strategy.Orders {
+			if order.Side == OrderSideBuy {
+				buyOrderID = orderID
+				break
+			}
+		}
+
+		// Simulate order filled
+		mockWS.SimulateOrder(&okx.WSOrder{
+			OrderID:     buyOrderID,
+			State:       "filled",
+			Side:        "buy",
+			FillPrice:   "2100",
+			AccFillSize: "0.5",
+		})
+
+		// Give some time for async processing
+		time.Sleep(100 * time.Millisecond)
+
+		assert.True(t, oppositeOrderPlaced, "Should place opposite sell order")
+
+		_ = manager.Stop(ctx)
+	})
+}
+
+func TestStrategyManager_EmergencyStop(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("performs emergency close", func(t *testing.T) {
+		cancelCalled := false
+		closeCalled := false
+
+		manager, mockRest, _ := newTestStrategyManager()
+		mockRest.GetPendingOrdersFunc = func(ctx context.Context, instID string) ([]okx.Order, error) {
+			return []okx.Order{{OrderID: "order1"}}, nil
+		}
+		mockRest.CancelBatchOrdersFunc = func(ctx context.Context, orders []okx.CancelOrderRequest) error {
+			cancelCalled = true
+			return nil
+		}
+		mockRest.GetPositionsFunc = func(ctx context.Context, instID string) ([]okx.Position, error) {
+			return []okx.Position{{Position: "1"}}, nil
+		}
+		mockRest.PlaceOrderFunc = func(ctx context.Context, req *okx.OrderRequest) (string, error) {
+			if req.ReduceOnly {
+				closeCalled = true
+			}
+			return "order-id", nil
+		}
+
+		params := GridParams{
+			InstID:          "ETH-USDT-SWAP",
+			LowerBound:      decimal.NewFromInt(2000),
+			UpperBound:      decimal.NewFromInt(2500),
+			GridCount:       5,
+			TotalInvestment: decimal.NewFromInt(10000),
+			Leverage:        10,
+			TradeMode:       TradeModeCross,
+		}
+
+		err := manager.Start(ctx, params, RiskParams{EmergencyStop: true})
+		require.NoError(t, err)
+
+		err = manager.EmergencyStop(ctx)
+		require.NoError(t, err)
+
+		assert.True(t, cancelCalled, "Should cancel orders")
+		assert.True(t, closeCalled, "Should close positions")
+
+		status := manager.GetStatus()
+		assert.Equal(t, StateEmergency, status.State)
+	})
+}
+
+func TestValidateParams(t *testing.T) {
+	manager := NewStrategyManager(nil, nil, zap.NewNop())
+
+	tests := []struct {
+		name        string
+		params      GridParams
+		expectError bool
+	}{
+		{
+			name: "valid params",
+			params: GridParams{
+				InstID:          "ETH-USDT-SWAP",
+				GridCount:       10,
+				TotalInvestment: decimal.NewFromInt(10000),
+				TradeMode:       TradeModeCross,
+			},
+			expectError: false,
+		},
+		{
+			name: "empty instID",
+			params: GridParams{
+				InstID:          "",
+				GridCount:       10,
+				TotalInvestment: decimal.NewFromInt(10000),
+				TradeMode:       TradeModeCross,
+			},
+			expectError: true,
+		},
+		{
+			name: "zero grid count",
+			params: GridParams{
+				InstID:          "ETH-USDT-SWAP",
+				GridCount:       0,
+				TotalInvestment: decimal.NewFromInt(10000),
+				TradeMode:       TradeModeCross,
+			},
+			expectError: true,
+		},
+		{
+			name: "zero investment",
+			params: GridParams{
+				InstID:          "ETH-USDT-SWAP",
+				GridCount:       10,
+				TotalInvestment: decimal.Zero,
+				TradeMode:       TradeModeCross,
+			},
+			expectError: true,
+		},
+		{
+			name: "invalid trade mode",
+			params: GridParams{
+				InstID:          "ETH-USDT-SWAP",
+				GridCount:       10,
+				TotalInvestment: decimal.NewFromInt(10000),
+				TradeMode:       TradeMode("invalid"),
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := manager.validateParams(tt.params)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestGetStatus_WithoutStrategy(t *testing.T) {
+	manager := NewStrategyManager(nil, nil, zap.NewNop())
+
+	status := manager.GetStatus()
+	assert.Equal(t, StateIdle, status.State)
+}
+
+func TestGetMetrics_WithoutStrategy(t *testing.T) {
+	manager := NewStrategyManager(nil, nil, zap.NewNop())
+
+	metrics := manager.GetMetrics()
+	assert.True(t, metrics.InitialEquity.IsZero())
+}
+
+func TestStrategyManager_Reconnect(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("auto reconnect on disconnect when enabled", func(t *testing.T) {
+		reconnectAttempted := false
+
+		manager, _, mockWS := newTestStrategyManager()
+		mockWS.ConnectPublicFunc = func(ctx context.Context) error {
+			reconnectAttempted = true
+			return nil
+		}
+
+		// Use custom config with auto reconnect enabled and short delays for testing
+		config := DefaultStrategyConfig()
+		config.EnableAutoReconnect = true
+		config.ReconnectBaseDelay = 10 * time.Millisecond
+		config.ReconnectMaxAttempts = 1
+		config.ReconnectTimeout = 100 * time.Millisecond
+
+		manager.config = config
+
+		params := GridParams{
+			InstID:          "ETH-USDT-SWAP",
+			LowerBound:      decimal.NewFromInt(2000),
+			UpperBound:      decimal.NewFromInt(2500),
+			GridCount:       5,
+			TotalInvestment: decimal.NewFromInt(10000),
+			Leverage:        10,
+			TradeMode:       TradeModeCross,
+		}
+
+		err := manager.Start(ctx, params, RiskParams{})
+		require.NoError(t, err)
+
+		// Simulate disconnection
+		manager.handleDisconnected("public", nil)
+
+		// Give time for reconnection attempt
+		time.Sleep(200 * time.Millisecond)
+
+		assert.True(t, reconnectAttempted, "Should attempt reconnection")
+
+		_ = manager.Stop(ctx)
+	})
+
+	t.Run("no reconnect when disabled", func(t *testing.T) {
+		reconnectAttempted := false
+
+		manager, _, mockWS := newTestStrategyManager()
+		mockWS.ConnectPublicFunc = func(ctx context.Context) error {
+			reconnectAttempted = true
+			return nil
+		}
+
+		// Disable auto reconnect
+		config := DefaultStrategyConfig()
+		config.EnableAutoReconnect = false
+		manager.config = config
+
+		params := GridParams{
+			InstID:          "ETH-USDT-SWAP",
+			LowerBound:      decimal.NewFromInt(2000),
+			UpperBound:      decimal.NewFromInt(2500),
+			GridCount:       5,
+			TotalInvestment: decimal.NewFromInt(10000),
+			Leverage:        10,
+			TradeMode:       TradeModeCross,
+		}
+
+		err := manager.Start(ctx, params, RiskParams{})
+		require.NoError(t, err)
+
+		// Reset the flag (ConnectPublic was called during Start)
+		reconnectAttempted = false
+
+		// Simulate disconnection
+		manager.handleDisconnected("public", nil)
+
+		// Give time to verify no reconnection attempt
+		time.Sleep(50 * time.Millisecond)
+
+		assert.False(t, reconnectAttempted, "Should not attempt reconnection when disabled")
+
+		_ = manager.Stop(ctx)
+	})
+
+	t.Run("no reconnect when strategy stopped", func(t *testing.T) {
+		manager, _, _ := newTestStrategyManager()
+
+		// Strategy not started, so handleDisconnected should not trigger reconnect
+		manager.handleDisconnected("public", nil)
+
+		// No panic or error expected
+	})
+
+	t.Run("calls OnReconnectFailed callback after max attempts", func(t *testing.T) {
+		callbackCalled := false
+		var callbackChannel string
+		var callbackAttempts int
+
+		manager, _, mockWS := newTestStrategyManager()
+
+		// Track connection attempts - first call succeeds (during Start), subsequent fail
+		connectCallCount := 0
+		mockWS.ConnectPublicFunc = func(ctx context.Context) error {
+			connectCallCount++
+			if connectCallCount == 1 {
+				return nil // First call during Start succeeds
+			}
+			return errors.New("connection failed")
+		}
+
+		config := DefaultStrategyConfig()
+		config.EnableAutoReconnect = true
+		config.ReconnectBaseDelay = 1 * time.Millisecond
+		config.ReconnectMaxAttempts = 2
+		config.ReconnectTimeout = 10 * time.Millisecond
+		config.OnReconnectFailed = func(channelType string, attempts int) {
+			callbackCalled = true
+			callbackChannel = channelType
+			callbackAttempts = attempts
+		}
+
+		manager.config = config
+
+		params := GridParams{
+			InstID:          "ETH-USDT-SWAP",
+			LowerBound:      decimal.NewFromInt(2000),
+			UpperBound:      decimal.NewFromInt(2500),
+			GridCount:       5,
+			TotalInvestment: decimal.NewFromInt(10000),
+			Leverage:        10,
+			TradeMode:       TradeModeCross,
+		}
+
+		err := manager.Start(ctx, params, RiskParams{})
+		require.NoError(t, err)
+
+		// Simulate disconnection
+		manager.handleDisconnected("public", nil)
+
+		// Wait for reconnection attempts to complete
+		time.Sleep(100 * time.Millisecond)
+
+		assert.True(t, callbackCalled, "OnReconnectFailed callback should be called")
+		assert.Equal(t, "public", callbackChannel)
+		assert.Equal(t, 2, callbackAttempts)
+
+		_ = manager.Stop(ctx)
+	})
+}
+
+func TestStrategyConfig_Validate(t *testing.T) {
+	t.Run("applies defaults for zero values", func(t *testing.T) {
+		config := StrategyConfig{}
+		config.Validate()
+
+		assert.Equal(t, 30*time.Second, config.RiskCheckInterval)
+		assert.Equal(t, 30*time.Second, config.RebuildTimeout)
+		assert.Equal(t, int32(4), config.OrderPrecision)
+		assert.Equal(t, "USDT", config.QuoteCurrency)
+		assert.Equal(t, 1*time.Second, config.ReconnectBaseDelay)
+		assert.Equal(t, 60*time.Second, config.ReconnectMaxDelay)
+		assert.Equal(t, 30*time.Second, config.ReconnectTimeout)
+	})
+
+	t.Run("preserves non-zero values", func(t *testing.T) {
+		config := StrategyConfig{
+			RiskCheckInterval: 10 * time.Second,
+			OrderPrecision:    6,
+			QuoteCurrency:     "USDC",
+		}
+		config.Validate()
+
+		assert.Equal(t, 10*time.Second, config.RiskCheckInterval)
+		assert.Equal(t, int32(6), config.OrderPrecision)
+		assert.Equal(t, "USDC", config.QuoteCurrency)
+	})
+}
+
+func TestWithConfig(t *testing.T) {
+	customConfig := StrategyConfig{
+		RiskCheckInterval: 10 * time.Second,
+		OrderPrecision:    6,
+		QuoteCurrency:     "USDC",
+	}
+
+	manager := NewStrategyManager(nil, nil, zap.NewNop(), WithConfig(customConfig))
+
+	assert.Equal(t, 10*time.Second, manager.config.RiskCheckInterval)
+	assert.Equal(t, int32(6), manager.config.OrderPrecision)
+	assert.Equal(t, "USDC", manager.config.QuoteCurrency)
+}

--- a/internal/strategy/grid/types.go
+++ b/internal/strategy/grid/types.go
@@ -1,0 +1,391 @@
+package grid
+
+import (
+	"sync"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// StrategyState represents the current state of the strategy
+type StrategyState string
+
+const (
+	StateIdle      StrategyState = "idle"      // Not started
+	StateRunning   StrategyState = "running"   // Running normally
+	StatePaused    StrategyState = "paused"    // Temporarily paused
+	StateStopping  StrategyState = "stopping"  // In process of stopping
+	StateStopped   StrategyState = "stopped"   // Stopped normally
+	StateEmergency StrategyState = "emergency" // Emergency stop triggered
+)
+
+// GridLevelStatus represents the status of a grid level
+type GridLevelStatus string
+
+const (
+	LevelEmpty       GridLevelStatus = "empty"        // No orders
+	LevelBuyPending  GridLevelStatus = "buy_pending"  // Buy order pending
+	LevelSellPending GridLevelStatus = "sell_pending" // Sell order pending
+	LevelBothPending GridLevelStatus = "both_pending" // Both orders pending
+)
+
+// OrderState represents the state of an order
+type OrderState string
+
+const (
+	OrderStateLive            OrderState = "live"             // Order is active
+	OrderStateFilled          OrderState = "filled"           // Order is filled
+	OrderStateCanceled        OrderState = "canceled"         // Order is canceled
+	OrderStatePartiallyFilled OrderState = "partially_filled" // Order is partially filled
+)
+
+// OrderSide represents the side of an order
+type OrderSide string
+
+const (
+	OrderSideBuy  OrderSide = "buy"  // Buy order
+	OrderSideSell OrderSide = "sell" // Sell order
+)
+
+// TradeMode represents the trading mode
+type TradeMode string
+
+const (
+	TradeModeCross    TradeMode = "cross"    // Cross margin mode
+	TradeModeIsolated TradeMode = "isolated" // Isolated margin mode
+)
+
+// IsValid checks if the trade mode is valid
+func (m TradeMode) IsValid() bool {
+	return m == TradeModeCross || m == TradeModeIsolated
+}
+
+// String returns the string representation of TradeMode
+func (m TradeMode) String() string {
+	return string(m)
+}
+
+// GridParams holds the grid strategy parameters
+type GridParams struct {
+	InstID          string          // Trading pair (e.g., "ETH-USDT-SWAP")
+	UpperBound      decimal.Decimal // Upper price boundary
+	LowerBound      decimal.Decimal // Lower price boundary
+	GridCount       int             // Number of grid intervals
+	TotalInvestment decimal.Decimal // Total investment amount
+	Leverage        int             // Leverage multiplier
+	TradeMode       TradeMode       // Trading mode (cross or isolated)
+}
+
+// RiskParams holds the risk management parameters
+type RiskParams struct {
+	StopLossRatio decimal.Decimal // Stop loss ratio (e.g., 0.2 = 20% loss)
+	MaxDrawdown   decimal.Decimal // Maximum allowed drawdown
+	EmergencyStop bool            // Enable emergency stop feature
+}
+
+// ReconnectFailedCallback is called when WebSocket reconnection fails after max attempts
+type ReconnectFailedCallback func(channelType string, attempts int)
+
+// StrategyConfig holds configurable strategy settings
+type StrategyConfig struct {
+	RiskCheckInterval      time.Duration           // Interval for risk checks (default: 30s)
+	RebuildTimeout         time.Duration           // Timeout for grid rebuild operations (default: 30s)
+	OrderPrecision         int32                   // Decimal places for order size (default: 4)
+	QuoteCurrency          string                  // Quote currency for balance queries (default: "USDT")
+	EnableAutoReconnect    bool                    // Enable automatic WebSocket reconnection (default: true)
+	ReconnectBaseDelay     time.Duration           // Base delay for reconnection attempts (default: 1s)
+	ReconnectMaxDelay      time.Duration           // Maximum delay for reconnection attempts (default: 60s)
+	ReconnectMaxAttempts   int                     // Maximum reconnection attempts, 0 = unlimited (default: 0)
+	ReconnectTimeout       time.Duration           // Timeout for each reconnection attempt (default: 30s)
+	OnReconnectFailed      ReconnectFailedCallback // Callback when reconnection fails (optional)
+	EmergencyStopOnFailure bool                    // Trigger emergency stop when reconnection fails (default: false)
+}
+
+// DefaultStrategyConfig returns the default strategy configuration
+func DefaultStrategyConfig() StrategyConfig {
+	return StrategyConfig{
+		RiskCheckInterval:    30 * time.Second,
+		RebuildTimeout:       30 * time.Second,
+		OrderPrecision:       4,
+		QuoteCurrency:        "USDT",
+		EnableAutoReconnect:  true,
+		ReconnectBaseDelay:   1 * time.Second,
+		ReconnectMaxDelay:    60 * time.Second,
+		ReconnectMaxAttempts: 0, // unlimited
+		ReconnectTimeout:     30 * time.Second,
+	}
+}
+
+// Validate validates the configuration and applies defaults for zero values
+func (c *StrategyConfig) Validate() {
+	if c.RiskCheckInterval <= 0 {
+		c.RiskCheckInterval = 30 * time.Second
+	}
+	if c.RebuildTimeout <= 0 {
+		c.RebuildTimeout = 30 * time.Second
+	}
+	if c.OrderPrecision <= 0 {
+		c.OrderPrecision = 4
+	}
+	if c.QuoteCurrency == "" {
+		c.QuoteCurrency = "USDT"
+	}
+	if c.ReconnectBaseDelay <= 0 {
+		c.ReconnectBaseDelay = 1 * time.Second
+	}
+	if c.ReconnectMaxDelay <= 0 {
+		c.ReconnectMaxDelay = 60 * time.Second
+	}
+	if c.ReconnectTimeout <= 0 {
+		c.ReconnectTimeout = 30 * time.Second
+	}
+}
+
+// GridLevel represents a single grid line
+type GridLevel struct {
+	Index       int             // Grid index (0 = lowest)
+	Price       decimal.Decimal // Price at this level
+	BuyOrderID  string          // Buy order ID (if any)
+	SellOrderID string          // Sell order ID (if any)
+	Status      GridLevelStatus // Current status
+	mu          sync.RWMutex    // Protects order IDs and status
+}
+
+// SetBuyOrder sets the buy order ID and updates status (thread-safe)
+func (l *GridLevel) SetBuyOrder(orderID string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.BuyOrderID = orderID
+	l.updateStatusLocked()
+}
+
+// SetSellOrder sets the sell order ID and updates status (thread-safe)
+func (l *GridLevel) SetSellOrder(orderID string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.SellOrderID = orderID
+	l.updateStatusLocked()
+}
+
+// ClearBuyOrder clears the buy order ID and updates status (thread-safe)
+func (l *GridLevel) ClearBuyOrder() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.BuyOrderID = ""
+	l.updateStatusLocked()
+}
+
+// ClearSellOrder clears the sell order ID and updates status (thread-safe)
+func (l *GridLevel) ClearSellOrder() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.SellOrderID = ""
+	l.updateStatusLocked()
+}
+
+// ClearAllOrders clears both order IDs and resets status (thread-safe)
+func (l *GridLevel) ClearAllOrders() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.BuyOrderID = ""
+	l.SellOrderID = ""
+	l.Status = LevelEmpty
+}
+
+// GetOrderIDs returns the current order IDs (thread-safe)
+func (l *GridLevel) GetOrderIDs() (buyID, sellID string) {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return l.BuyOrderID, l.SellOrderID
+}
+
+// GetStatus returns the current status (thread-safe)
+func (l *GridLevel) GetStatus() GridLevelStatus {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return l.Status
+}
+
+// updateStatusLocked updates status based on current order IDs (must hold lock)
+func (l *GridLevel) updateStatusLocked() {
+	hasBuy := l.BuyOrderID != ""
+	hasSell := l.SellOrderID != ""
+
+	switch {
+	case hasBuy && hasSell:
+		l.Status = LevelBothPending
+	case hasBuy:
+		l.Status = LevelBuyPending
+	case hasSell:
+		l.Status = LevelSellPending
+	default:
+		l.Status = LevelEmpty
+	}
+}
+
+// GridOrder represents a grid order
+type GridOrder struct {
+	OrderID    string          // Order ID from exchange
+	InstID     string          // Trading pair
+	Side       OrderSide       // Order side (buy or sell)
+	Price      decimal.Decimal // Order price
+	Size       decimal.Decimal // Order size
+	GridIndex  int             // Corresponding grid index
+	State      OrderState      // Order state
+	FilledSize decimal.Decimal // Filled size
+	CreateTime time.Time       // Creation time
+	UpdateTime time.Time       // Last update time
+	mu         sync.RWMutex    // Protects mutable fields
+}
+
+// UpdateState updates the order state (thread-safe)
+func (o *GridOrder) UpdateState(state OrderState) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.State = state
+	o.UpdateTime = time.Now()
+}
+
+// UpdateFilled updates the filled size and state (thread-safe)
+func (o *GridOrder) UpdateFilled(filledSize decimal.Decimal, state OrderState) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.FilledSize = filledSize
+	o.State = state
+	o.UpdateTime = time.Now()
+}
+
+// GetState returns the current state (thread-safe)
+func (o *GridOrder) GetState() OrderState {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+	return o.State
+}
+
+// StrategyMetrics holds the strategy performance metrics
+type StrategyMetrics struct {
+	InitialEquity decimal.Decimal // Initial equity
+	CurrentEquity decimal.Decimal // Current equity
+	UnrealizedPnL decimal.Decimal // Unrealized P&L
+	RealizedPnL   decimal.Decimal // Realized P&L
+	TotalTrades   int             // Total number of trades
+	WinTrades     int             // Number of winning trades
+	MaxDrawdown   decimal.Decimal // Maximum drawdown experienced
+	PeakEquity    decimal.Decimal // Peak equity for drawdown calculation
+	LastPrice     decimal.Decimal // Last market price
+	UpdateTime    time.Time       // Last update time
+}
+
+// Strategy represents the grid trading strategy state
+type Strategy struct {
+	ID         string                // Strategy ID
+	Params     GridParams            // Grid parameters
+	RiskParams RiskParams            // Risk parameters
+	State      StrategyState         // Current state
+	Levels     []*GridLevel          // Grid levels
+	Orders     map[string]*GridOrder // Active orders (orderID -> GridOrder)
+	Metrics    StrategyMetrics       // Performance metrics
+	OrderSize  decimal.Decimal       // Size per order
+
+	mu        sync.RWMutex // Protects state
+	startTime time.Time    // Strategy start time
+	stopTime  time.Time    // Strategy stop time
+}
+
+// NewStrategy creates a new strategy instance
+func NewStrategy(id string, params GridParams, riskParams RiskParams) *Strategy {
+	return &Strategy{
+		ID:         id,
+		Params:     params,
+		RiskParams: riskParams,
+		State:      StateIdle,
+		Levels:     make([]*GridLevel, 0),
+		Orders:     make(map[string]*GridOrder),
+		Metrics:    StrategyMetrics{},
+	}
+}
+
+// GetState returns the current strategy state
+func (s *Strategy) GetState() StrategyState {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.State
+}
+
+// SetState sets the strategy state
+func (s *Strategy) SetState(state StrategyState) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.State = state
+}
+
+// IsRunning returns true if strategy is running
+func (s *Strategy) IsRunning() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.State == StateRunning
+}
+
+// AddOrder adds an order to the strategy
+func (s *Strategy) AddOrder(order *GridOrder) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.Orders[order.OrderID] = order
+}
+
+// RemoveOrder removes an order from the strategy
+func (s *Strategy) RemoveOrder(orderID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.Orders, orderID)
+}
+
+// GetOrder returns an order by ID
+func (s *Strategy) GetOrder(orderID string) (*GridOrder, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	order, ok := s.Orders[orderID]
+	return order, ok
+}
+
+// GetMetrics returns a copy of the current metrics
+func (s *Strategy) GetMetrics() StrategyMetrics {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.Metrics
+}
+
+// UpdateMetrics updates the strategy metrics
+func (s *Strategy) UpdateMetrics(fn func(*StrategyMetrics)) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	fn(&s.Metrics)
+}
+
+// GetStartTime returns the strategy start time
+func (s *Strategy) GetStartTime() time.Time {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.startTime
+}
+
+// GetStopTime returns the strategy stop time
+func (s *Strategy) GetStopTime() time.Time {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.stopTime
+}
+
+// SetStartTime sets the strategy start time
+func (s *Strategy) SetStartTime(t time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.startTime = t
+}
+
+// SetStopTime sets the strategy stop time
+func (s *Strategy) SetStopTime(t time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.stopTime = t
+}


### PR DESCRIPTION
  - Add Calculator for grid level calculation and order size computation
  - Add OrderManager for order placement and lifecycle management
  - Add RiskController with stop-loss, max drawdown, and emergency close
  - Add StrategyManager with WebSocket integration and auto-reconnection
  - Implement type-safe enums (TradeMode, OrderSide, OrderState, StrategyState)
  - Add configurable StrategyConfig with functional options pattern
  - Implement thread-safe operations with sync.RWMutex and atomic flags
  - Add exponential backoff reconnection with configurable callbacks